### PR TITLE
feat: Event-specific BQ views and tree error visibility

### DIFF
--- a/src/bigquery_agent_analytics/__init__.py
+++ b/src/bigquery_agent_analytics/__init__.py
@@ -62,11 +62,14 @@ try:
   from .trace import Trace
   from .trace import TraceFilter
 
+  from .views import ViewManager
+
   __all__.extend([
       "Client",
       "Trace",
       "Span",
       "TraceFilter",
+      "ViewManager",
       "CodeEvaluator",
       "LLMAsJudge",
       "EvaluationReport",

--- a/src/bigquery_agent_analytics/views.py
+++ b/src/bigquery_agent_analytics/views.py
@@ -1,0 +1,320 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Event-specific BigQuery views for agent analytics.
+
+Creates standard (non-materialized) BigQuery views that unnest the
+generic ``agent_events_v2`` table into per-event-type views with typed
+columns.  Every view retains the standard identity headers:
+``timestamp``, ``agent``, ``session_id``, ``invocation_id``.
+
+Example usage::
+
+    from bigquery_agent_analytics.views import ViewManager
+
+    vm = ViewManager(
+        project_id="my-project",
+        dataset_id="analytics",
+        table_id="agent_events_v2",
+    )
+    vm.create_all_views()              # create all per-event views
+    vm.create_view("LLM_REQUEST")      # create a single view
+    print(vm.get_view_sql("TOOL_CALL"))  # inspect SQL without creating
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from google.cloud import bigquery
+
+logger = logging.getLogger("bigquery_agent_analytics." + __name__)
+
+# ------------------------------------------------------------------ #
+# Standard header columns included in every view                       #
+# ------------------------------------------------------------------ #
+
+_STANDARD_HEADERS = """\
+  timestamp,
+  agent,
+  session_id,
+  invocation_id,
+  user_id,
+  trace_id,
+  span_id,
+  parent_span_id,
+  status,
+  error_message,
+  is_truncated"""
+
+# ------------------------------------------------------------------ #
+# Per-event-type column definitions                                    #
+# ------------------------------------------------------------------ #
+# Each entry maps an event_type string to a tuple of
+# (view_suffix, extra_columns_sql).  ``extra_columns_sql`` extracts
+# event-specific fields from the ``content`` and ``attributes`` JSON
+# columns into typed top-level columns.
+
+_EVENT_VIEW_DEFS: dict[str, tuple[str, str]] = {
+    "LLM_REQUEST": (
+        "llm_requests",
+        """\
+  JSON_EXTRACT_SCALAR(attributes, '$.model') AS model,
+  JSON_EXTRACT_SCALAR(attributes, '$.model_version') AS model_version,
+  JSON_EXTRACT(attributes, '$.llm_config') AS llm_config,
+  JSON_EXTRACT(attributes, '$.tools') AS tools,
+  content""",
+    ),
+    "LLM_RESPONSE": (
+        "llm_responses",
+        """\
+  JSON_EXTRACT_SCALAR(attributes, '$.model') AS model,
+  JSON_EXTRACT_SCALAR(
+    attributes, '$.usage_metadata.prompt_token_count'
+  ) AS prompt_tokens,
+  JSON_EXTRACT_SCALAR(
+    attributes, '$.usage_metadata.candidates_token_count'
+  ) AS candidate_tokens,
+  JSON_EXTRACT_SCALAR(
+    attributes, '$.usage_metadata.total_token_count'
+  ) AS total_tokens,
+  JSON_EXTRACT_SCALAR(latency_ms, '$.total_ms') AS total_ms,
+  JSON_EXTRACT_SCALAR(
+    latency_ms, '$.time_to_first_token_ms'
+  ) AS time_to_first_token_ms,
+  content""",
+    ),
+    "LLM_ERROR": (
+        "llm_errors",
+        """\
+  JSON_EXTRACT_SCALAR(attributes, '$.model') AS model,
+  error_message,
+  JSON_EXTRACT_SCALAR(latency_ms, '$.total_ms') AS total_ms,
+  content""",
+    ),
+    "TOOL_STARTING": (
+        "tool_starts",
+        """\
+  JSON_EXTRACT_SCALAR(content, '$.tool') AS tool_name,
+  JSON_EXTRACT_SCALAR(content, '$.tool_origin') AS tool_origin,
+  JSON_EXTRACT(content, '$.args') AS tool_args""",
+    ),
+    "TOOL_COMPLETED": (
+        "tool_completions",
+        """\
+  JSON_EXTRACT_SCALAR(content, '$.tool') AS tool_name,
+  JSON_EXTRACT_SCALAR(content, '$.tool_origin') AS tool_origin,
+  JSON_EXTRACT(content, '$.result') AS tool_result,
+  JSON_EXTRACT_SCALAR(latency_ms, '$.total_ms') AS total_ms""",
+    ),
+    "TOOL_ERROR": (
+        "tool_errors",
+        """\
+  JSON_EXTRACT_SCALAR(content, '$.tool') AS tool_name,
+  JSON_EXTRACT_SCALAR(content, '$.tool_origin') AS tool_origin,
+  JSON_EXTRACT(content, '$.args') AS tool_args,
+  error_message,
+  JSON_EXTRACT_SCALAR(latency_ms, '$.total_ms') AS total_ms""",
+    ),
+    "USER_MESSAGE_RECEIVED": (
+        "user_messages",
+        """\
+  JSON_EXTRACT_SCALAR(content, '$.text_summary') AS text_summary,
+  content""",
+    ),
+    "AGENT_STARTING": (
+        "agent_starts",
+        """\
+  JSON_EXTRACT_SCALAR(
+    attributes, '$.root_agent_name'
+  ) AS root_agent_name,
+  content""",
+    ),
+    "AGENT_COMPLETED": (
+        "agent_completions",
+        """\
+  JSON_EXTRACT_SCALAR(
+    attributes, '$.root_agent_name'
+  ) AS root_agent_name,
+  JSON_EXTRACT_SCALAR(latency_ms, '$.total_ms') AS total_ms,
+  content""",
+    ),
+    "INVOCATION_STARTING": (
+        "invocation_starts",
+        """\
+  JSON_EXTRACT_SCALAR(
+    attributes, '$.root_agent_name'
+  ) AS root_agent_name,
+  content""",
+    ),
+    "INVOCATION_COMPLETED": (
+        "invocation_completions",
+        """\
+  JSON_EXTRACT_SCALAR(
+    attributes, '$.root_agent_name'
+  ) AS root_agent_name,
+  JSON_EXTRACT_SCALAR(latency_ms, '$.total_ms') AS total_ms,
+  content""",
+    ),
+    "STATE_DELTA": (
+        "state_deltas",
+        """\
+  JSON_EXTRACT(attributes, '$.state_delta') AS state_delta,
+  content""",
+    ),
+}
+
+# ------------------------------------------------------------------ #
+# View Template                                                        #
+# ------------------------------------------------------------------ #
+
+_VIEW_SQL_TEMPLATE = """\
+CREATE OR REPLACE VIEW `{project}.{dataset}.{view_name}` AS
+SELECT
+{standard_headers},
+{extra_columns}
+FROM `{project}.{dataset}.{table}`
+WHERE event_type = '{event_type}'
+"""
+
+
+def _build_view_sql(
+    project: str,
+    dataset: str,
+    table: str,
+    event_type: str,
+    view_name: str,
+    extra_columns: str,
+) -> str:
+  """Builds the CREATE OR REPLACE VIEW SQL for one event type."""
+  return _VIEW_SQL_TEMPLATE.format(
+      project=project,
+      dataset=dataset,
+      table=table,
+      view_name=view_name,
+      event_type=event_type,
+      standard_headers=_STANDARD_HEADERS,
+      extra_columns=extra_columns,
+  )
+
+
+# ------------------------------------------------------------------ #
+# ViewManager                                                          #
+# ------------------------------------------------------------------ #
+
+
+class ViewManager:
+  """Manages per-event-type BigQuery views over the agent events table.
+
+  Args:
+      project_id: Google Cloud project ID.
+      dataset_id: BigQuery dataset containing agent events.
+      table_id: Source table name (default ``agent_events_v2``).
+      view_prefix: Optional prefix for view names (e.g. ``"adk_"``).
+      bq_client: Optional pre-configured BigQuery client.
+  """
+
+  def __init__(
+      self,
+      project_id: str,
+      dataset_id: str,
+      table_id: str = "agent_events_v2",
+      view_prefix: str = "adk_",
+      bq_client: Optional[bigquery.Client] = None,
+  ) -> None:
+    self.project_id = project_id
+    self.dataset_id = dataset_id
+    self.table_id = table_id
+    self.view_prefix = view_prefix
+    self._bq_client = bq_client
+
+  @property
+  def bq_client(self) -> bigquery.Client:
+    if self._bq_client is None:
+      self._bq_client = bigquery.Client(
+          project=self.project_id
+      )
+    return self._bq_client
+
+  @property
+  def available_event_types(self) -> list[str]:
+    """Returns the list of event types with view definitions."""
+    return sorted(_EVENT_VIEW_DEFS.keys())
+
+  def get_view_name(self, event_type: str) -> str:
+    """Returns the fully-qualified view name for an event type."""
+    suffix = _EVENT_VIEW_DEFS[event_type][0]
+    return f"{self.view_prefix}{suffix}"
+
+  def get_view_sql(self, event_type: str) -> str:
+    """Returns the SQL for a single event-type view.
+
+    Args:
+        event_type: One of the supported event type strings.
+
+    Returns:
+        The CREATE OR REPLACE VIEW SQL statement.
+
+    Raises:
+        KeyError: If the event_type is not recognized.
+    """
+    if event_type not in _EVENT_VIEW_DEFS:
+      raise KeyError(
+          f"Unknown event_type '{event_type}'. "
+          f"Available: {self.available_event_types}"
+      )
+    suffix, extra_columns = _EVENT_VIEW_DEFS[event_type]
+    view_name = f"{self.view_prefix}{suffix}"
+    return _build_view_sql(
+        project=self.project_id,
+        dataset=self.dataset_id,
+        table=self.table_id,
+        event_type=event_type,
+        view_name=view_name,
+        extra_columns=extra_columns,
+    )
+
+  def create_view(self, event_type: str) -> None:
+    """Creates (or replaces) the view for one event type.
+
+    Args:
+        event_type: The event type to create a view for.
+    """
+    sql = self.get_view_sql(event_type)
+    view_name = self.get_view_name(event_type)
+    logger.info("Creating view %s.%s.%s",
+                self.project_id, self.dataset_id, view_name)
+    self.bq_client.query(sql).result()
+    logger.info("View %s created successfully.", view_name)
+
+  def create_all_views(self) -> dict[str, str]:
+    """Creates views for all supported event types.
+
+    Returns:
+        A dict mapping event_type to view name for each created view.
+    """
+    created = {}
+    for event_type in _EVENT_VIEW_DEFS:
+      try:
+        self.create_view(event_type)
+        created[event_type] = self.get_view_name(event_type)
+      except Exception as e:
+        logger.error(
+            "Failed to create view for %s: %s",
+            event_type,
+            e,
+            exc_info=True,
+        )
+    return created

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ViewManager and event-specific view generation."""
+
+from unittest import mock
+
+import pytest
+
+from bigquery_agent_analytics.views import _EVENT_VIEW_DEFS
+from bigquery_agent_analytics.views import ViewManager
+
+
+PROJECT = "test-project"
+DATASET = "analytics"
+TABLE = "agent_events_v2"
+
+
+@pytest.fixture
+def vm():
+  return ViewManager(
+      project_id=PROJECT,
+      dataset_id=DATASET,
+      table_id=TABLE,
+      bq_client=mock.MagicMock(),
+  )
+
+
+class TestViewManager:
+
+  def test_available_event_types(self, vm):
+    types = vm.available_event_types
+    assert "LLM_REQUEST" in types
+    assert "TOOL_STARTING" in types
+    assert "TOOL_COMPLETED" in types
+    assert "TOOL_ERROR" in types
+    assert "STATE_DELTA" in types
+    assert len(types) == len(_EVENT_VIEW_DEFS)
+
+  def test_get_view_name(self, vm):
+    assert vm.get_view_name("LLM_REQUEST") == "adk_llm_requests"
+    assert vm.get_view_name("TOOL_STARTING") == "adk_tool_starts"
+
+  def test_get_view_sql_contains_event_filter(self, vm):
+    sql = vm.get_view_sql("LLM_REQUEST")
+    assert "WHERE event_type = 'LLM_REQUEST'" in sql
+    assert "CREATE OR REPLACE VIEW" in sql
+    assert f"`{PROJECT}.{DATASET}." in sql
+
+  def test_get_view_sql_has_standard_headers(self, vm):
+    sql = vm.get_view_sql("TOOL_STARTING")
+    for header in [
+        "timestamp", "agent", "session_id",
+        "invocation_id", "span_id",
+    ]:
+      assert header in sql
+
+  def test_get_view_sql_llm_request_columns(self, vm):
+    sql = vm.get_view_sql("LLM_REQUEST")
+    assert "model" in sql
+    assert "model_version" in sql
+    assert "llm_config" in sql
+
+  def test_get_view_sql_tool_starting_columns(self, vm):
+    sql = vm.get_view_sql("TOOL_STARTING")
+    assert "tool_name" in sql
+    assert "tool_origin" in sql
+    assert "tool_args" in sql
+
+  def test_get_view_sql_tool_completed_columns(self, vm):
+    sql = vm.get_view_sql("TOOL_COMPLETED")
+    assert "tool_name" in sql
+    assert "tool_result" in sql
+    assert "total_ms" in sql
+
+  def test_get_view_sql_llm_response_tokens(self, vm):
+    sql = vm.get_view_sql("LLM_RESPONSE")
+    assert "prompt_tokens" in sql
+    assert "candidate_tokens" in sql
+    assert "total_tokens" in sql
+
+  def test_get_view_sql_unknown_event_raises(self, vm):
+    with pytest.raises(KeyError, match="Unknown event_type"):
+      vm.get_view_sql("NONEXISTENT_TYPE")
+
+  def test_create_view_executes_sql(self, vm):
+    vm.create_view("LLM_REQUEST")
+    vm.bq_client.query.assert_called_once()
+    sql = vm.bq_client.query.call_args[0][0]
+    assert "LLM_REQUEST" in sql
+    vm.bq_client.query.return_value.result.assert_called_once()
+
+  def test_create_all_views(self, vm):
+    created = vm.create_all_views()
+    assert len(created) == len(_EVENT_VIEW_DEFS)
+    assert vm.bq_client.query.call_count == len(_EVENT_VIEW_DEFS)
+
+  def test_create_all_views_handles_errors(self, vm):
+    vm.bq_client.query.side_effect = Exception("BQ error")
+    created = vm.create_all_views()
+    assert len(created) == 0
+
+  def test_custom_prefix(self):
+    vm = ViewManager(
+        project_id=PROJECT,
+        dataset_id=DATASET,
+        view_prefix="custom_",
+        bq_client=mock.MagicMock(),
+    )
+    assert vm.get_view_name("LLM_REQUEST") == "custom_llm_requests"
+    sql = vm.get_view_sql("LLM_REQUEST")
+    assert "custom_llm_requests" in sql
+
+  def test_all_event_defs_produce_valid_sql(self, vm):
+    """Every defined event type produces SQL without errors."""
+    for event_type in _EVENT_VIEW_DEFS:
+      sql = vm.get_view_sql(event_type)
+      assert "CREATE OR REPLACE VIEW" in sql
+      assert f"event_type = '{event_type}'" in sql


### PR DESCRIPTION
## Summary
Implements two of the five enhancements from google/adk-python#4554 (the SDK-side items):

- **Event-Specific BigQuery Views (Item 1):** New `ViewManager` class in `views.py` that generates `CREATE OR REPLACE VIEW` SQL for each of the 12 event types. Each view unnests `content` and `attributes` JSON into typed columns (e.g., `tool_name`, `tool_origin`, `model`, `prompt_tokens`) while retaining standard identity headers (`timestamp`, `agent`, `session_id`, `invocation_id`). Configurable view prefix (default `adk_`).
- **Tree Structure & Error Visibility (Item 2):** Enhanced `Span` with `is_error`, `subtree_has_error`, and `failure_context` properties for explicit error reporting at each tree node. New `Trace.errors()` method returns all error spans with full failure context (event_type, tool, origin, error_message). Tree rendering now shows warning icon (⚠) on parent nodes whose subtree contains errors, making failures immediately visible at every level. Added `STATE_DELTA` and HITL event types to `EventType` enum.

### Files Changed
- `src/bigquery_agent_analytics/views.py` — New `ViewManager` class (12 event type definitions)
- `src/bigquery_agent_analytics/trace.py` — Error visibility properties, `errors()` method, EventType updates
- `src/bigquery_agent_analytics/__init__.py` — Export `ViewManager`
- `tests/test_views.py` — 14 new tests
- `tests/test_sdk_trace.py` — 15 new tests

## Test plan
- [x] 14 view tests (SQL generation, headers, column extraction, create/create_all, error handling)
- [x] 15 trace tests (is_error, subtree propagation, failure_context, Trace.errors(), render warning icons, EventType enum)
- [x] All 50 SDK tests pass (36 trace + 14 views)

Relates to google/adk-python#4554

🤖 Generated with [Claude Code](https://claude.com/claude-code)