### PR TITLE
Rename default table from agent_events_v2 to agent_events

### DIFF
--- a/SDK.md
+++ b/SDK.md
@@ -18,7 +18,7 @@ from bigquery_agent_analytics import Client
 client = Client(
     project_id="my-gcp-project",
     dataset_id="agent_analytics",
-    table_id="agent_events_v2",       # default table name
+    table_id="agent_events",       # default table name
     location="us-central1",           # BigQuery dataset location
     gcs_bucket_name="my-trace-bucket",# optional: for GCS-offloaded payloads
     endpoint="gemini-2.5-flash",      # AI.GENERATE endpoint for LLM evals
@@ -30,7 +30,7 @@ client = Client(
 |-----------|------|---------|-------------|
 | `project_id` | `str` | *required* | Google Cloud project ID |
 | `dataset_id` | `str` | *required* | BigQuery dataset containing traces |
-| `table_id` | `str` | `"agent_events_v2"` | BigQuery table name |
+| `table_id` | `str` | `"agent_events"` | BigQuery table name |
 | `location` | `str` | `"us-central1"` | Dataset location |
 | `gcs_bucket_name` | `str \| None` | `None` | GCS bucket for offloaded payloads |
 | `verify_schema` | `bool` | `True` | Validate table schema on init |

--- a/docs/design.md
+++ b/docs/design.md
@@ -70,7 +70,7 @@ This SDK bridges the gap between raw telemetry and actionable agent analytics.
                   │  Writes events
                   ▼
 ┌──────────────────────────────────────────────────────────┐
-│              BigQuery (agent_events_v2)                   │
+│              BigQuery (agent_events)                   │
 │                                                          │
 │  Partitioned by DATE(timestamp)                          │
 │  Clustered by event_type, agent, user_id                 │
@@ -240,7 +240,7 @@ The `Client` class is the primary interface for users who want a batteries-inclu
 Client(
     project_id: str,              # GCP project
     dataset_id: str,              # BigQuery dataset
-    table_id: str = "agent_events_v2",
+    table_id: str = "agent_events",
     location: str = "us-central1",
     gcs_bucket_name: str | None,  # For GCS-offloaded payload access
     verify_schema: bool = True,   # Schema validation on init
@@ -840,7 +840,7 @@ Returns `bigframes.DataFrame` that can be displayed directly in Jupyter notebook
 
 ## 5. Data Model
 
-### 5.1 BigQuery Table Schema (`agent_events_v2`)
+### 5.1 BigQuery Table Schema (`agent_events`)
 
 The canonical schema written by the ADK plugin and read by this SDK:
 

--- a/examples/e2e_demo.py
+++ b/examples/e2e_demo.py
@@ -72,7 +72,7 @@ from bigquery_agent_analytics.trace_evaluator import MatchType
 # ---------------------------------------------------------------------------
 PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT", "test-project-0728-467323")
 DATASET_ID = os.environ.get("BQ_DATASET", "agent_analytics")
-TABLE_ID = os.environ.get("BQ_TABLE", "agent_events_v2")
+TABLE_ID = os.environ.get("BQ_TABLE", "agent_events")
 MODEL_NAME = os.environ.get("MODEL_NAME", "gemini-3-flash-preview")
 GCP_LOCATION = os.environ.get("GOOGLE_CLOUD_LOCATION", "global")
 LOCATION = "US"

--- a/examples/e2e_demo_output.txt
+++ b/examples/e2e_demo_output.txt
@@ -3,7 +3,7 @@
 ================================================================
   Project  : test-project-0728-467323
   Dataset  : agent_analytics
-  Table    : agent_events_v2
+  Table    : agent_events
   Model    : gemini-3-flash-preview
   Location : US
 
@@ -250,7 +250,7 @@ Trace: e-3a59113e-29b5-499d-b81a-0c77f09d43d2 | Session: e2e-6fa45acfba30 | 1937
 
 [latency]
 Evaluation Report: latency_evaluator
-  Dataset: test-project-0728-467323.agent_analytics.agent_events_v2 WHERE session_id IN UNNEST(@session_ids)
+  Dataset: test-project-0728-467323.agent_analytics.agent_events WHERE session_id IN UNNEST(@session_ids)
   Sessions: 3
   Passed: 3 (100%)
   Failed: 0
@@ -259,7 +259,7 @@ Evaluation Report: latency_evaluator
 
 [turn_count]
 Evaluation Report: turn_count_evaluator
-  Dataset: test-project-0728-467323.agent_analytics.agent_events_v2 WHERE session_id IN UNNEST(@session_ids)
+  Dataset: test-project-0728-467323.agent_analytics.agent_events WHERE session_id IN UNNEST(@session_ids)
   Sessions: 3
   Passed: 3 (100%)
   Failed: 0
@@ -268,7 +268,7 @@ Evaluation Report: turn_count_evaluator
 
 [error_rate]
 Evaluation Report: error_rate_evaluator
-  Dataset: test-project-0728-467323.agent_analytics.agent_events_v2 WHERE session_id IN UNNEST(@session_ids)
+  Dataset: test-project-0728-467323.agent_analytics.agent_events WHERE session_id IN UNNEST(@session_ids)
   Sessions: 3
   Passed: 3 (100%)
   Failed: 0
@@ -277,7 +277,7 @@ Evaluation Report: error_rate_evaluator
 
 [token_efficiency]
 Evaluation Report: token_efficiency_evaluator
-  Dataset: test-project-0728-467323.agent_analytics.agent_events_v2 WHERE session_id IN UNNEST(@session_ids)
+  Dataset: test-project-0728-467323.agent_analytics.agent_events WHERE session_id IN UNNEST(@session_ids)
   Sessions: 3
   Passed: 0 (0%)
   Failed: 3
@@ -288,7 +288,7 @@ Evaluation Report: token_efficiency_evaluator
 --- 2c. LLM-as-Judge Evaluation ---
 
 Evaluation Report: correctness_judge
-  Dataset: test-project-0728-467323.agent_analytics.agent_events_v2 WHERE session_id IN UNNEST(@session_ids)
+  Dataset: test-project-0728-467323.agent_analytics.agent_events WHERE session_id IN UNNEST(@session_ids)
   Sessions: 3
   Passed: 2 (67%)
   Failed: 1
@@ -412,4 +412,4 @@ user experience inefficiencies.
     - e2e-451318888b27
     - e2e-9936a6077916
     - e2e-6fa45acfba30
-  Traces logged to: test-project-0728-467323.agent_analytics.agent_events_v2
+  Traces logged to: test-project-0728-467323.agent_analytics.agent_events

--- a/examples/e2e_notebook_demo.ipynb
+++ b/examples/e2e_notebook_demo.ipynb
@@ -1,64 +1,64 @@
 {
  "cells": [
-   {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "copyright-header"
-      },
-      "outputs": [],
-      "source": [
-        "# Copyright 2025 Google LLC\n",
-        "#\n",
-        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "#      https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "notebook-affordances"
-      },
-      "source": [
-        "# Demo Plan: BigQuery for Agent Ops - Unified Platform\n",
-        "\n",
-        "<table align=\"left\">\n",
-        "\n",
-        "  <td>\n",
-        "    <a href=\"https://colab.research.google.com/github/haiyuan-eng-google/demo_BQ_agent_analytics_plugin_notebook/blob/main/Demo_Plan_BigQuery_for_Agent_Ops_Unified_Platform_Public.ipynb\">\n",
-        "      <img src=\"https://raw.githubusercontent.com/googleapis/python-bigquery-dataframes/refs/heads/main/third_party/logo/colab-logo.png\" alt=\"Colab logo\"> Run in Colab\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://github.com/haiyuan-eng-google/demo_BQ_agent_analytics_plugin_notebook/blob/main/Demo_Plan_BigQuery_for_Agent_Ops_Unified_Platform_Public.ipynb\">\n",
-        "      <img src=\"https://raw.githubusercontent.com/googleapis/python-bigquery-dataframes/refs/heads/main/third_party/logo/github-logo.png\" width=\"32\" alt=\"GitHub logo\">\n",
-        "      View on GitHub\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/haiyuan-eng-google/demo_BQ_agent_analytics_plugin_notebook/main/Demo_Plan_BigQuery_for_Agent_Ops_Unified_Platform_Public.ipynb\">\n",
-        "      <img src=\"https://www.gstatic.com/images/branding/product/1x/google_cloud_48dp.png\" alt=\"Vertex AI logo\" width=\"32\">\n",
-        "      Open in Vertex AI Workbench\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://console.cloud.google.com/bigquery/import?url=https://github.com/haiyuan-eng-google/demo_BQ_agent_analytics_plugin_notebook/blob/main/Demo_Plan_BigQuery_for_Agent_Ops_Unified_Platform_Public.ipynb\">\n",
-        "      <img src=\"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTW1gvOovVlbZAIZylUtf5Iu8-693qS1w5NJw&s\" alt=\"BQ logo\" width=\"35\">\n",
-        "      Open in BQ Studio\n",
-        "    </a>\n",
-        "  </td>\n",
-        "</table>"
-      ]
-    },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "copyright-header"
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2025 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#      https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "notebook-affordances"
+   },
+   "source": [
+    "# Demo Plan: BigQuery for Agent Ops - Unified Platform\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "\n",
+    "  <td>\n",
+    "    <a href=\"https://colab.research.google.com/github/haiyuan-eng-google/demo_BQ_agent_analytics_plugin_notebook/blob/main/Demo_Plan_BigQuery_for_Agent_Ops_Unified_Platform_Public.ipynb\">\n",
+    "      <img src=\"https://raw.githubusercontent.com/googleapis/python-bigquery-dataframes/refs/heads/main/third_party/logo/colab-logo.png\" alt=\"Colab logo\"> Run in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://github.com/haiyuan-eng-google/demo_BQ_agent_analytics_plugin_notebook/blob/main/Demo_Plan_BigQuery_for_Agent_Ops_Unified_Platform_Public.ipynb\">\n",
+    "      <img src=\"https://raw.githubusercontent.com/googleapis/python-bigquery-dataframes/refs/heads/main/third_party/logo/github-logo.png\" width=\"32\" alt=\"GitHub logo\">\n",
+    "      View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/haiyuan-eng-google/demo_BQ_agent_analytics_plugin_notebook/main/Demo_Plan_BigQuery_for_Agent_Ops_Unified_Platform_Public.ipynb\">\n",
+    "      <img src=\"https://www.gstatic.com/images/branding/product/1x/google_cloud_48dp.png\" alt=\"Vertex AI logo\" width=\"32\">\n",
+    "      Open in Vertex AI Workbench\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/bigquery/import?url=https://github.com/haiyuan-eng-google/demo_BQ_agent_analytics_plugin_notebook/blob/main/Demo_Plan_BigQuery_for_Agent_Ops_Unified_Platform_Public.ipynb\">\n",
+    "      <img src=\"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTW1gvOovVlbZAIZylUtf5Iu8-693qS1w5NJw&s\" alt=\"BQ logo\" width=\"35\">\n",
+    "      Open in BQ Studio\n",
+    "    </a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
   {
    "cell_type": "markdown",
    "metadata": {},
@@ -87,39 +87,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "# Colab authentication\n",
-    "try:\n",
-    "    from google.colab import auth\n",
-    "    auth.authenticate_user()\n",
-    "    print(\"Colab authentication successful.\")\n",
-    "except ImportError:\n",
-    "    print(\"Not running in Colab — using default credentials.\")\n",
-    "\n",
-    "# ---------- Configuration ----------\n",
-    "PROJECT_ID = os.environ.get(\"GOOGLE_CLOUD_PROJECT\", \"test-project-0728-467323\")\n",
-    "DATASET_ID = os.environ.get(\"BQ_DATASET\", \"agent_analytics\")\n",
-    "TABLE_ID = os.environ.get(\"BQ_TABLE\", \"agent_events_v2\")\n",
-    "MODEL_NAME = os.environ.get(\"MODEL_NAME\", \"gemini-3-flash-preview\")\n",
-    "LOCATION = \"US\"\n",
-    "APP_NAME = \"e2e_notebook_demo\"\n",
-    "USER_ID = \"demo_user\"\n",
-    "\n",
-    "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"true\"\n",
-    "os.environ[\"GOOGLE_CLOUD_PROJECT\"] = PROJECT_ID\n",
-    "os.environ[\"GOOGLE_CLOUD_LOCATION\"] = \"global\"\n",
-    "\n",
-    "# Enable async in Jupyter\n",
-    "import nest_asyncio\n",
-    "nest_asyncio.apply()\n",
-    "\n",
-    "print(f\"Project  : {PROJECT_ID}\")\n",
-    "print(f\"Dataset  : {DATASET_ID}\")\n",
-    "print(f\"Table    : {TABLE_ID}\")\n",
-    "print(f\"Model    : {MODEL_NAME}\")"
-   ]
+   "source": "import os\n\n# Colab authentication\ntry:\n    from google.colab import auth\n    auth.authenticate_user()\n    print(\"Colab authentication successful.\")\nexcept ImportError:\n    print(\"Not running in Colab — using default credentials.\")\n\n# ---------- Configuration ----------\nPROJECT_ID = os.environ.get(\"GOOGLE_CLOUD_PROJECT\", \"test-project-0728-467323\")\nDATASET_ID = os.environ.get(\"BQ_DATASET\", \"agent_analytics\")\nTABLE_ID = os.environ.get(\"BQ_TABLE\", \"agent_events\")\nMODEL_NAME = os.environ.get(\"MODEL_NAME\", \"gemini-3-flash-preview\")\nLOCATION = \"US\"\nAPP_NAME = \"e2e_notebook_demo\"\nUSER_ID = \"demo_user\"\n\nos.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"true\"\nos.environ[\"GOOGLE_CLOUD_PROJECT\"] = PROJECT_ID\nos.environ[\"GOOGLE_CLOUD_LOCATION\"] = \"global\"\n\n# Enable async in Jupyter\nimport nest_asyncio\nnest_asyncio.apply()\n\nprint(f\"Project  : {PROJECT_ID}\")\nprint(f\"Dataset  : {DATASET_ID}\")\nprint(f\"Table    : {TABLE_ID}\")\nprint(f\"Model    : {MODEL_NAME}\")"
   },
   {
    "cell_type": "markdown",

--- a/src/bigquery_agent_analytics/ai_ml_integration.py
+++ b/src/bigquery_agent_analytics/ai_ml_integration.py
@@ -396,7 +396,7 @@ class EmbeddingSearchClient:
       project_id: str,
       dataset_id: str,
       embeddings_table: str = "trace_embeddings",
-      source_table: str = "agent_events_v2",
+      source_table: str = "agent_events",
       client: Optional[bigquery.Client] = None,
       embedding_model: Optional[str] = None,
   ) -> None:
@@ -637,7 +637,7 @@ class AnomalyDetector:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       client: Optional[bigquery.Client] = None,
   ) -> None:
     """Initializes AnomalyDetector.
@@ -1008,7 +1008,7 @@ class BatchEvaluator:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       client: Optional[bigquery.Client] = None,
       eval_model: Optional[str] = None,
       endpoint: Optional[str] = None,

--- a/src/bigquery_agent_analytics/bigframes_evaluator.py
+++ b/src/bigquery_agent_analytics/bigframes_evaluator.py
@@ -28,7 +28,7 @@ Example usage::
     evaluator = BigFramesEvaluator(
         project_id="my-project",
         dataset_id="analytics",
-        table_id="agent_events_v2",
+        table_id="agent_events",
     )
 
     scores_df = evaluator.evaluate_sessions(max_sessions=50)
@@ -82,7 +82,7 @@ class BigFramesEvaluator:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       endpoint: Optional[str] = None,
       connection_id: Optional[str] = None,
   ) -> None:

--- a/src/bigquery_agent_analytics/client.py
+++ b/src/bigquery_agent_analytics/client.py
@@ -191,7 +191,7 @@ class Client:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       location: str = "us-central1",
       gcs_bucket_name: Optional[str] = None,
       verify_schema: bool = True,

--- a/src/bigquery_agent_analytics/feedback.py
+++ b/src/bigquery_agent_analytics/feedback.py
@@ -21,7 +21,7 @@ Example usage::
 
     client = Client(project_id="p", dataset_id="d")
     report = client.drift_detection(
-        dataset="agent_events_v2",
+        dataset="agent_events",
         filters=TraceFilter(start_time=...),
         golden_dataset="golden_questions_v1",
     )

--- a/src/bigquery_agent_analytics/memory_service.py
+++ b/src/bigquery_agent_analytics/memory_service.py
@@ -26,7 +26,7 @@ Example usage:
     memory_service = BigQueryMemoryService(
         project_id="my-project",
         dataset_id="agent_analytics",
-        table_id="agent_events_v2",
+        table_id="agent_events",
     )
 
     # Retrieve relevant past context
@@ -165,7 +165,7 @@ class BigQuerySessionMemory:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       client: Optional[bigquery.Client] = None,
   ) -> None:
     """Initializes BigQuerySessionMemory.
@@ -297,7 +297,7 @@ class BigQueryEpisodicMemory:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       embeddings_table_id: Optional[str] = None,
       client: Optional[bigquery.Client] = None,
       embedding_model: Optional[str] = None,
@@ -717,7 +717,7 @@ class UserProfileBuilder:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       client: Optional[bigquery.Client] = None,
   ) -> None:
     """Initializes UserProfileBuilder.
@@ -891,7 +891,7 @@ class BigQueryMemoryService(BaseMemoryService):
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       client: Optional[bigquery.Client] = None,
       embedding_model: Optional[str] = None,
   ) -> None:

--- a/src/bigquery_agent_analytics/trace_evaluator.py
+++ b/src/bigquery_agent_analytics/trace_evaluator.py
@@ -26,7 +26,7 @@ Example usage:
     evaluator = BigQueryTraceEvaluator(
         project_id="my-project",
         dataset_id="agent_analytics",
-        table_id="agent_events_v2",
+        table_id="agent_events",
     )
 
     results = await evaluator.evaluate_session(
@@ -396,7 +396,7 @@ class BigQueryTraceEvaluator:
       evaluator = BigQueryTraceEvaluator(
           project_id="my-project",
           dataset_id="agent_analytics",
-          table_id="agent_events_v2",
+          table_id="agent_events",
       )
 
       result = await evaluator.evaluate_session(
@@ -465,7 +465,7 @@ Required JSON format:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       client: Optional[bigquery.Client] = None,
       llm_judge_model: Optional[str] = None,
   ) -> None:
@@ -474,7 +474,7 @@ Required JSON format:
     Args:
         project_id: Google Cloud project ID.
         dataset_id: BigQuery dataset ID containing trace data.
-        table_id: BigQuery table ID. Defaults to "agent_events_v2".
+        table_id: BigQuery table ID. Defaults to "agent_events".
         client: Optional BigQuery client. Created if not provided.
         llm_judge_model: Optional model name for LLM-as-judge evaluation.
     """

--- a/src/bigquery_agent_analytics/views.py
+++ b/src/bigquery_agent_analytics/views.py
@@ -15,7 +15,7 @@
 """Event-specific BigQuery views for agent analytics.
 
 Creates standard (non-materialized) BigQuery views that unnest the
-generic ``agent_events_v2`` table into per-event-type views with typed
+generic ``agent_events`` table into per-event-type views with typed
 columns.  Every view retains the standard identity headers:
 ``timestamp``, ``agent``, ``session_id``, ``invocation_id``.
 
@@ -26,7 +26,7 @@ Example usage::
     vm = ViewManager(
         project_id="my-project",
         dataset_id="analytics",
-        table_id="agent_events_v2",
+        table_id="agent_events",
     )
     vm.create_all_views()              # create all per-event views
     vm.create_view("LLM_REQUEST")      # create a single view
@@ -221,7 +221,7 @@ class ViewManager:
   Args:
       project_id: Google Cloud project ID.
       dataset_id: BigQuery dataset containing agent events.
-      table_id: Source table name (default ``agent_events_v2``).
+      table_id: Source table name (default ``agent_events``).
       view_prefix: Optional prefix for view names (e.g. ``"adk_"``).
       bq_client: Optional pre-configured BigQuery client.
   """
@@ -230,7 +230,7 @@ class ViewManager:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       view_prefix: str = "adk_",
       bq_client: Optional[bigquery.Client] = None,
   ) -> None:

--- a/tests/test_bigframes_evaluator.py
+++ b/tests/test_bigframes_evaluator.py
@@ -32,7 +32,7 @@ class TestBigFramesEvaluatorInit:
     )
     assert ev.endpoint == "gemini-2.5-flash"
     assert ev.connection_id is None
-    assert ev.table_id == "agent_events_v2"
+    assert ev.table_id == "agent_events"
 
   def test_custom_endpoint(self):
     ev = BigFramesEvaluator(

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -412,7 +412,7 @@ class TestAIGenerateJudge:
     report = client._ai_generate_judge(
         evaluator,
         criterion,
-        "agent_events_v2",
+        "agent_events",
         "TRUE",
         [],
     )
@@ -449,7 +449,7 @@ class TestAIGenerateJudge:
     evaluator = LLMAsJudge.correctness()
     report = client._evaluate_llm_judge(
         evaluator,
-        "agent_events_v2",
+        "agent_events",
         "TRUE",
         [],
     )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -24,7 +24,7 @@ from bigquery_agent_analytics.views import ViewManager
 
 PROJECT = "test-project"
 DATASET = "analytics"
-TABLE = "agent_events_v2"
+TABLE = "agent_events"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Renamed the default table name from `agent_events_v2` to `agent_events` across the entire SDK to align with the ADK plugin's default (`BigQueryAgentAnalyticsPlugin` uses `agent_events` by default)
- Updated all 15 files: 7 source modules, 3 test files, 2 example files, 1 notebook, SDK.md, and design doc
- This is a **breaking change** for users relying on the previous default; pass `table_id="agent_events_v2"` explicitly to preserve the old behavior

## Files changed
- `src/bigquery_agent_analytics/client.py` — default `table_id` parameter
- `src/bigquery_agent_analytics/bigframes_evaluator.py` — default + docstring
- `src/bigquery_agent_analytics/trace_evaluator.py` — default + docstring + examples
- `src/bigquery_agent_analytics/memory_service.py` — 5 class defaults
- `src/bigquery_agent_analytics/views.py` — default + docstring
- `src/bigquery_agent_analytics/feedback.py` — example docstring
- `src/bigquery_agent_analytics/ai_ml_integration.py` — 3 class defaults
- `tests/test_bigframes_evaluator.py`, `tests/test_views.py`, `tests/test_sdk_client.py`
- `examples/e2e_demo.py`, `examples/e2e_demo_output.txt`, `examples/e2e_notebook_demo.ipynb`
- `SDK.md`, `docs/design.md`

## Test plan
- [ ] Verify all unit tests pass with updated defaults
- [ ] Confirm SDK examples work against a BigQuery dataset with `agent_events` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)