### PR TITLE
fix: Query get_trace() by trace_id instead of session_id

### DIFF
--- a/src/bigquery_agent_analytics/trace.py
+++ b/src/bigquery_agent_analytics/trace.py
@@ -22,7 +22,7 @@ hierarchical DAG view of the agent's reasoning steps.
 Example usage::
 
     client = Client(project_id="my-project", dataset_id="analytics")
-    trace = client.get_trace("session-123")
+    trace = client.get_trace("trace-123")
     trace.render()  # Prints hierarchical DAG in notebook/terminal
 """
 

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -173,10 +173,10 @@ class TestClientGetTrace:
         verify_schema=False,
         bq_client=mock_bq,
     )
-    trace = client.get_trace("sess-1")
+    trace = client.get_trace("trace-1")
 
-    assert trace.session_id == "sess-1"
     assert trace.trace_id == "trace-1"
+    assert trace.session_id == "sess-1"
     assert len(trace.spans) == 3
     assert trace.user_id == "user-1"
 


### PR DESCRIPTION
## Summary
- Fixes #10: `Client.get_trace()` was querying by `session_id` column instead of `trace_id`, causing incorrect results or `ValueError` when users pass an actual `trace_id`
- Updated `_GET_TRACE_QUERY` SQL to filter on `WHERE trace_id = @trace_id`
- Fixed parameter binding, docstrings, and Trace construction to correctly distinguish `trace_id` from `session_id`
- Updated test to call `get_trace("trace-1")` instead of `get_trace("sess-1")`

## Test plan
- [x] All 352 existing tests pass
- [ ] Manually verify `client.get_trace(<actual_trace_id>)` returns the correct trace against a live BigQuery table
