### PR TITLE
fix: Sync SDK schema with latest ADK BigQuery plugin

### DIFF
--- a/src/bigquery_agent_analytics/__init__.py
+++ b/src/bigquery_agent_analytics/__init__.py
@@ -31,7 +31,7 @@ Quick start::
     from bigquery_agent_analytics import Client
 
     client = Client(project_id="my-project", dataset_id="analytics")
-    trace = client.get_trace("session-123")
+    trace = client.get_trace("trace-123")
     trace.render()
 
     # Generate insights report
@@ -58,6 +58,8 @@ try:
   from .insights import InsightsConfig
   from .insights import InsightsReport
   from .insights import SessionFacet
+  from .trace import ContentPart
+  from .trace import ObjectRef
   from .trace import Span
   from .trace import Trace
   from .trace import TraceFilter
@@ -68,6 +70,8 @@ try:
       "Client",
       "Trace",
       "Span",
+      "ContentPart",
+      "ObjectRef",
       "TraceFilter",
       "ViewManager",
       "CodeEvaluator",

--- a/src/bigquery_agent_analytics/ai_ml_integration.py
+++ b/src/bigquery_agent_analytics/ai_ml_integration.py
@@ -396,7 +396,7 @@ class EmbeddingSearchClient:
       project_id: str,
       dataset_id: str,
       embeddings_table: str = "trace_embeddings",
-      source_table: str = "agent_events_v2",
+      source_table: str = "agent_events",
       client: Optional[bigquery.Client] = None,
       embedding_model: Optional[str] = None,
   ) -> None:
@@ -637,7 +637,7 @@ class AnomalyDetector:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       client: Optional[bigquery.Client] = None,
   ) -> None:
     """Initializes AnomalyDetector.
@@ -1008,7 +1008,7 @@ class BatchEvaluator:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       client: Optional[bigquery.Client] = None,
       eval_model: Optional[str] = None,
       endpoint: Optional[str] = None,

--- a/src/bigquery_agent_analytics/bigframes_evaluator.py
+++ b/src/bigquery_agent_analytics/bigframes_evaluator.py
@@ -82,7 +82,7 @@ class BigFramesEvaluator:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       endpoint: Optional[str] = None,
       connection_id: Optional[str] = None,
   ) -> None:

--- a/src/bigquery_agent_analytics/memory_service.py
+++ b/src/bigquery_agent_analytics/memory_service.py
@@ -26,7 +26,7 @@ Example usage:
     memory_service = BigQueryMemoryService(
         project_id="my-project",
         dataset_id="agent_analytics",
-        table_id="agent_events_v2",
+        table_id="agent_events",
     )
 
     # Retrieve relevant past context
@@ -165,7 +165,7 @@ class BigQuerySessionMemory:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       client: Optional[bigquery.Client] = None,
   ) -> None:
     """Initializes BigQuerySessionMemory.
@@ -297,7 +297,7 @@ class BigQueryEpisodicMemory:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       embeddings_table_id: Optional[str] = None,
       client: Optional[bigquery.Client] = None,
       embedding_model: Optional[str] = None,
@@ -717,7 +717,7 @@ class UserProfileBuilder:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       client: Optional[bigquery.Client] = None,
   ) -> None:
     """Initializes UserProfileBuilder.
@@ -891,7 +891,7 @@ class BigQueryMemoryService(BaseMemoryService):
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       client: Optional[bigquery.Client] = None,
       embedding_model: Optional[str] = None,
   ) -> None:

--- a/src/bigquery_agent_analytics/trace_evaluator.py
+++ b/src/bigquery_agent_analytics/trace_evaluator.py
@@ -465,7 +465,7 @@ Required JSON format:
       self,
       project_id: str,
       dataset_id: str,
-      table_id: str = "agent_events_v2",
+      table_id: str = "agent_events",
       client: Optional[bigquery.Client] = None,
       llm_judge_model: Optional[str] = None,
   ) -> None:

--- a/tests/test_bigframes_evaluator.py
+++ b/tests/test_bigframes_evaluator.py
@@ -32,7 +32,7 @@ class TestBigFramesEvaluatorInit:
     )
     assert ev.endpoint == "gemini-2.5-flash"
     assert ev.connection_id is None
-    assert ev.table_id == "agent_events_v2"
+    assert ev.table_id == "agent_events"
 
   def test_custom_endpoint(self):
     ev = BigFramesEvaluator(

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -173,10 +173,10 @@ class TestClientGetTrace:
         verify_schema=False,
         bq_client=mock_bq,
     )
-    trace = client.get_trace("sess-1")
+    trace = client.get_trace("trace-1")
 
-    assert trace.session_id == "sess-1"
     assert trace.trace_id == "trace-1"
+    assert trace.session_id == "sess-1"
     assert len(trace.spans) == 3
     assert trace.user_id == "user-1"
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -24,7 +24,7 @@ from bigquery_agent_analytics.views import ViewManager
 
 PROJECT = "test-project"
 DATASET = "analytics"
-TABLE = "agent_events_v2"
+TABLE = "agent_events"
 
 
 @pytest.fixture
@@ -46,6 +46,12 @@ class TestViewManager:
     assert "TOOL_COMPLETED" in types
     assert "TOOL_ERROR" in types
     assert "STATE_DELTA" in types
+    assert "HITL_CREDENTIAL_REQUEST" in types
+    assert "HITL_CONFIRMATION_REQUEST" in types
+    assert "HITL_INPUT_REQUEST" in types
+    assert "HITL_CREDENTIAL_REQUEST_COMPLETED" in types
+    assert "HITL_CONFIRMATION_REQUEST_COMPLETED" in types
+    assert "HITL_INPUT_REQUEST_COMPLETED" in types
     assert len(types) == len(_EVENT_VIEW_DEFS)
 
   def test_get_view_name(self, vm):


### PR DESCRIPTION
## Summary
Aligns the SDK with the latest `google-adk` BigQuery Agent Analytics plugin ([`bigquery_agent_analytics_plugin.py`](https://github.com/google/adk-python/blob/main/src/google/adk/plugins/bigquery_agent_analytics_plugin.py)) to fix schema mismatches that cause silent failures for users following the ADK quickstart.

- **Default table name** changed from `agent_events_v2` to `agent_events` across all 8 source files (matches plugin's `BigQueryLoggerConfig` default)
- **`ContentPart`** extended with `object_ref` (nested `ObjectRef`), `part_index`, and `part_attributes` to match plugin's `content_parts` RECORD schema
- **`final_response`** now checks `LLM_RESPONSE` first (plugin writes `null` for `AGENT_COMPLETED` content), falling back to `AGENT_COMPLETED` for backward compatibility
- **`Span.summary`** adds `raw` content fallback for `AGENT_STARTING` events (plugin writes plain-string content, not JSON)
- **HITL event views** added for all 6 Human-in-the-Loop event types (`HITL_CREDENTIAL_REQUEST`, `HITL_CONFIRMATION_REQUEST`, `HITL_INPUT_REQUEST` + their `_COMPLETED` counterparts)
- **`tool_origin`** now exposed in `Trace.tool_calls()` output (values: `LOCAL`, `MCP`, `A2A`, `SUB_AGENT`, `TRANSFER_AGENT`, `UNKNOWN`)
- **`_REQUIRED_COLUMNS`** expanded from 4 to all 16 columns the SDK actively queries, so `_verify_schema` warns about any missing columns
- **`get_trace()`** fixed to query by `trace_id` instead of `session_id` (fixes #10)

## Test plan
- [x] All 358 tests pass (6 new tests added for `ObjectRef`, `tool_origin`, `final_response` priority, raw content fallback, HITL views)
- [ ] Verify against a live BigQuery table created by the latest ADK plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)