### PR TITLE
fix: P0 bug fixes for LLM judge and new analytics features

### DIFF
--- a/src/bigquery_agent_analytics/__init__.py
+++ b/src/bigquery_agent_analytics/__init__.py
@@ -234,6 +234,37 @@ except ImportError as e:
       e,
   )
 
+# Event Semantics
+try:
+  from .event_semantics import ALL_KNOWN_EVENT_TYPES
+  from .event_semantics import ERROR_SQL_PREDICATE
+  from .event_semantics import EVENT_FAMILIES
+  from .event_semantics import extract_response_text
+  from .event_semantics import is_error_event
+  from .event_semantics import is_hitl_event
+  from .event_semantics import is_tool_event
+  from .event_semantics import RESPONSE_EVENT_TYPES
+  from .event_semantics import tool_outcome
+
+  __all__.extend(
+      [
+          "is_error_event",
+          "extract_response_text",
+          "is_tool_event",
+          "tool_outcome",
+          "is_hitl_event",
+          "ERROR_SQL_PREDICATE",
+          "RESPONSE_EVENT_TYPES",
+          "EVENT_FAMILIES",
+          "ALL_KNOWN_EVENT_TYPES",
+      ]
+  )
+except ImportError as e:
+  logger.debug(
+      "Could not import event semantics: %s.",
+      e,
+  )
+
 # BigFrames Evaluator (optional bigframes dependency)
 try:
   from .bigframes_evaluator import BigFramesEvaluator

--- a/src/bigquery_agent_analytics/event_semantics.py
+++ b/src/bigquery_agent_analytics/event_semantics.py
@@ -1,0 +1,188 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Canonical event semantic layer for BigQuery Agent Analytics SDK.
+
+Centralizes the logic for interpreting ADK plugin events so that
+every module (evaluators, memory, insights, trace) uses consistent
+definitions for "final response", "error event", "tool outcome",
+etc.  Import helpers from this module instead of re-implementing
+event-type checks in each module.
+
+Example usage::
+
+    from bigquery_agent_analytics.event_semantics import (
+        is_error_event,
+        extract_response_text,
+    )
+
+    for span in trace.spans:
+        if is_error_event(span.event_type, span.error_message,
+                          span.status):
+            print("Error:", span.error_message)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+# ------------------------------------------------------------------ #
+# Error Detection                                                      #
+# ------------------------------------------------------------------ #
+
+
+def is_error_event(
+    event_type: str,
+    error_message: Optional[str] = None,
+    status: str = "OK",
+) -> bool:
+  """Returns True when the event represents an error.
+
+  Uses the canonical predicate aligned with the ADK plugin:
+  the event type ends with ``_ERROR``, the ``error_message``
+  column is populated, or the ``status`` column is ``'ERROR'``.
+
+  Args:
+      event_type: The event_type column value.
+      error_message: The error_message column value.
+      status: The status column value.
+  """
+  return (
+      event_type.endswith("_ERROR")
+      or error_message is not None
+      or status == "ERROR"
+  )
+
+
+# SQL fragment for use in BigQuery WHERE clauses.
+ERROR_SQL_PREDICATE = (
+    "(ENDS_WITH(event_type, '_ERROR')"
+    " OR error_message IS NOT NULL"
+    " OR status = 'ERROR')"
+)
+
+# Negated version for filtering out errors.
+NO_ERROR_SQL_PREDICATE = (
+    "NOT ENDS_WITH(event_type, '_ERROR')"
+    " AND error_message IS NULL"
+    " AND status != 'ERROR'"
+)
+
+
+# ------------------------------------------------------------------ #
+# Response Extraction                                                  #
+# ------------------------------------------------------------------ #
+
+
+def extract_response_text(content: dict[str, Any]) -> Optional[str]:
+  """Extracts user-visible response text from a content dict.
+
+  Checks keys in priority order: ``response``, ``text_summary``,
+  ``text``, ``raw``.
+
+  Args:
+      content: The parsed ``content`` JSON column.
+
+  Returns:
+      The response text or ``None``.
+  """
+  if not isinstance(content, dict):
+    return str(content) if content else None
+  return (
+      content.get("response")
+      or content.get("text_summary")
+      or content.get("text")
+      or content.get("raw")
+      or None
+  )
+
+
+# Event types that carry the final agent response, in priority order.
+RESPONSE_EVENT_TYPES = ("LLM_RESPONSE", "AGENT_COMPLETED")
+
+
+# ------------------------------------------------------------------ #
+# Tool Outcome                                                         #
+# ------------------------------------------------------------------ #
+
+
+def is_tool_event(event_type: str) -> bool:
+  """Returns True for tool-related event types."""
+  return event_type in (
+      "TOOL_STARTING",
+      "TOOL_COMPLETED",
+      "TOOL_ERROR",
+  )
+
+
+def tool_outcome(event_type: str, status: str = "OK") -> str:
+  """Returns a canonical tool outcome string.
+
+  Args:
+      event_type: The event type.
+      status: The status column.
+
+  Returns:
+      One of ``"success"``, ``"error"``, or ``"in_progress"``.
+  """
+  if event_type == "TOOL_ERROR" or status == "ERROR":
+    return "error"
+  if event_type == "TOOL_COMPLETED":
+    return "success"
+  return "in_progress"
+
+
+# ------------------------------------------------------------------ #
+# Event Classification                                                 #
+# ------------------------------------------------------------------ #
+
+
+def is_hitl_event(event_type: str) -> bool:
+  """Returns True for Human-in-the-Loop event types."""
+  return event_type.startswith("HITL_")
+
+
+def is_hitl_completed(event_type: str) -> bool:
+  """Returns True for completed HITL events."""
+  return event_type.startswith("HITL_") and event_type.endswith("_COMPLETED")
+
+
+# All event types known to the SDK, grouped by family.
+EVENT_FAMILIES = {
+    "user": ["USER_MESSAGE_RECEIVED"],
+    "invocation": [
+        "INVOCATION_STARTING",
+        "INVOCATION_COMPLETED",
+    ],
+    "agent": ["AGENT_STARTING", "AGENT_COMPLETED"],
+    "llm": ["LLM_REQUEST", "LLM_RESPONSE", "LLM_ERROR"],
+    "tool": [
+        "TOOL_STARTING",
+        "TOOL_COMPLETED",
+        "TOOL_ERROR",
+    ],
+    "state": ["STATE_DELTA"],
+    "hitl": [
+        "HITL_CONFIRMATION_REQUEST",
+        "HITL_CONFIRMATION_REQUEST_COMPLETED",
+        "HITL_CREDENTIAL_REQUEST",
+        "HITL_CREDENTIAL_REQUEST_COMPLETED",
+        "HITL_INPUT_REQUEST",
+        "HITL_INPUT_REQUEST_COMPLETED",
+    ],
+}
+
+ALL_KNOWN_EVENT_TYPES = [
+    et for family in EVENT_FAMILIES.values() for et in family
+]

--- a/tests/test_event_semantics.py
+++ b/tests/test_event_semantics.py
@@ -1,0 +1,127 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for event_semantics module."""
+
+from bigquery_agent_analytics.event_semantics import ALL_KNOWN_EVENT_TYPES
+from bigquery_agent_analytics.event_semantics import EVENT_FAMILIES
+from bigquery_agent_analytics.event_semantics import extract_response_text
+from bigquery_agent_analytics.event_semantics import is_error_event
+from bigquery_agent_analytics.event_semantics import is_hitl_event
+from bigquery_agent_analytics.event_semantics import is_tool_event
+from bigquery_agent_analytics.event_semantics import tool_outcome
+
+
+class TestIsErrorEvent:
+  """Tests for is_error_event()."""
+
+  def test_error_event_type(self):
+    assert is_error_event("LLM_ERROR") is True
+    assert is_error_event("TOOL_ERROR") is True
+
+  def test_error_message_set(self):
+    assert is_error_event("TOOL_COMPLETED", error_message="fail") is True
+
+  def test_status_error(self):
+    assert is_error_event("TOOL_COMPLETED", status="ERROR") is True
+
+  def test_no_error(self):
+    assert is_error_event("TOOL_COMPLETED") is False
+    assert is_error_event("LLM_RESPONSE") is False
+
+  def test_combined(self):
+    assert (
+        is_error_event("TOOL_ERROR", error_message="x", status="ERROR") is True
+    )
+
+
+class TestExtractResponseText:
+  """Tests for extract_response_text()."""
+
+  def test_response_key(self):
+    assert extract_response_text({"response": "hello"}) == "hello"
+
+  def test_text_summary_key(self):
+    assert extract_response_text({"text_summary": "hi"}) == "hi"
+
+  def test_text_key(self):
+    assert extract_response_text({"text": "hey"}) == "hey"
+
+  def test_priority_order(self):
+    content = {"text_summary": "a", "response": "b"}
+    assert extract_response_text(content) == "b"
+
+  def test_empty_dict(self):
+    assert extract_response_text({}) is None
+
+  def test_none_content(self):
+    assert extract_response_text(None) is None
+
+  def test_string_content(self):
+    assert extract_response_text("raw text") == "raw text"
+
+
+class TestIsToolEvent:
+  """Tests for is_tool_event()."""
+
+  def test_tool_events(self):
+    assert is_tool_event("TOOL_STARTING") is True
+    assert is_tool_event("TOOL_COMPLETED") is True
+    assert is_tool_event("TOOL_ERROR") is True
+
+  def test_non_tool_events(self):
+    assert is_tool_event("LLM_REQUEST") is False
+    assert is_tool_event("AGENT_COMPLETED") is False
+
+
+class TestToolOutcome:
+  """Tests for tool_outcome()."""
+
+  def test_completed(self):
+    assert tool_outcome("TOOL_COMPLETED") == "success"
+
+  def test_error_type(self):
+    assert tool_outcome("TOOL_ERROR") == "error"
+
+  def test_error_status(self):
+    assert tool_outcome("TOOL_COMPLETED", status="ERROR") == "error"
+
+  def test_starting(self):
+    assert tool_outcome("TOOL_STARTING") == "in_progress"
+
+
+class TestIsHitlEvent:
+  """Tests for is_hitl_event()."""
+
+  def test_hitl_events(self):
+    assert is_hitl_event("HITL_CONFIRMATION_REQUEST") is True
+    assert is_hitl_event("HITL_INPUT_REQUEST_COMPLETED") is True
+
+  def test_non_hitl(self):
+    assert is_hitl_event("LLM_REQUEST") is False
+
+
+class TestEventFamilies:
+  """Tests for EVENT_FAMILIES and ALL_KNOWN_EVENT_TYPES."""
+
+  def test_all_families_present(self):
+    assert "user" in EVENT_FAMILIES
+    assert "llm" in EVENT_FAMILIES
+    assert "tool" in EVENT_FAMILIES
+    assert "hitl" in EVENT_FAMILIES
+    assert "state" in EVENT_FAMILIES
+
+  def test_all_known_types_consistent(self):
+    total = sum(len(v) for v in EVENT_FAMILIES.values())
+    assert len(ALL_KNOWN_EVENT_TYPES) == total


### PR DESCRIPTION
## Summary

- **Fix multi-criterion LLM judge**: `_evaluate_llm_judge` now evaluates ALL criteria instead of returning after the first one (premature `return` inside the loop)
- **Fix false pass on empty scores**: `all()` on empty `scores.values()` returns `True` in Python; now requires `bool(scores)` as a guard
- **Fix API fallback ignoring table/params**: `_api_judge` now queries the correct table with the correct WHERE clause and parameters instead of falling back to default `self.table_id`
- **Auto-detect table**: `table_id="auto"` probes `INFORMATION_SCHEMA.TABLES` for `agent_events` then `agent_events_v2`
- **Event semantic layer**: New `event_semantics` module with canonical helpers (`is_error_event`, `extract_response_text`, `is_tool_event`, `tool_outcome`, `is_hitl_event`)
- **Strict evaluation mode**: `evaluate(strict=True)` marks sessions with empty/unparseable scores as failed
- **HITL analytics**: `client.hitl_metrics()` returns HITL event counts and completion rates
- **Doctor command**: `client.doctor()` checks schema, event coverage, and AI.GENERATE availability

## Test plan

- [x] All 392 tests pass (`pytest tests/ -v`)
- [x] New tests for multi-criterion evaluation (all criteria evaluated)
- [x] New tests for empty score false-pass fix
- [x] New tests for API judge using correct table/params
- [x] New tests for strict evaluation mode
- [x] New tests for auto-detect table (happy path, fallback, error)
- [x] New tests for doctor command
- [x] New tests for HITL metrics
- [x] New test file `test_event_semantics.py` with comprehensive coverage
- [x] Code formatted with pyink + isort

🤖 Generated with [Claude Code](https://claude.com/claude-code)