### PR TITLE
fix: E2E bugs — UDF body indentation, JSON cast, unused import

### DIFF
--- a/deploy/python_udf/register.sql
+++ b/deploy/python_udf/register.sql
@@ -49,12 +49,12 @@ OPTIONS (
   description = """Returns TRUE when the event represents an error."""
 )
 AS r"""
-    def bqaa_is_error_event(event_type, error_message, status):
-        return (
-            event_type.endswith("_ERROR")
-            or error_message is not None
-            or status == "ERROR"
-        )
+def bqaa_is_error_event(event_type, error_message, status):
+    return (
+        event_type.endswith("_ERROR")
+        or error_message is not None
+        or status == "ERROR"
+    )
 """;
 
 -- Returns a canonical tool outcome: 'success', 'error', or 'in_progress'.
@@ -69,12 +69,12 @@ OPTIONS (
   description = """Returns a canonical tool outcome: 'success', 'error', or 'in_progress'."""
 )
 AS r"""
-    def bqaa_tool_outcome(event_type, status):
-        if event_type == "TOOL_ERROR" or status == "ERROR":
-            return "error"
-        if event_type == "TOOL_COMPLETED":
-            return "success"
-        return "in_progress"
+def bqaa_tool_outcome(event_type, status):
+    if event_type == "TOOL_ERROR" or status == "ERROR":
+        return "error"
+    if event_type == "TOOL_COMPLETED":
+        return "success"
+    return "in_progress"
 """;
 
 -- Extracts user-visible response text from a JSON content string.
@@ -89,24 +89,24 @@ OPTIONS (
   description = """Extracts user-visible response text from a JSON content string."""
 )
 AS r"""
-    import json
+import json
 
-    def bqaa_extract_response_text(content_json):
-        if not content_json:
-            return None
-        try:
-            content = json.loads(content_json)
-        except (json.JSONDecodeError, TypeError):
-            return str(content_json) if content_json else None
-        if not isinstance(content, dict):
-            return str(content) if content else None
-        return (
-            content.get("response")
-            or content.get("text_summary")
-            or content.get("text")
-            or content.get("raw")
-            or None
-        )
+def bqaa_extract_response_text(content_json):
+    if not content_json:
+        return None
+    try:
+        content = json.loads(content_json)
+    except (json.JSONDecodeError, TypeError):
+        return str(content_json) if content_json else None
+    if not isinstance(content, dict):
+        return str(content) if content else None
+    return (
+        content.get("response")
+        or content.get("text_summary")
+        or content.get("text")
+        or content.get("raw")
+        or None
+    )
 """;
 
 
@@ -126,12 +126,12 @@ OPTIONS (
   description = """Score average latency against a threshold (0.0-1.0)."""
 )
 AS r"""
-    def bqaa_score_latency(avg_latency_ms, threshold_ms):
-        if avg_latency_ms <= 0:
-            return 1.0
-        if avg_latency_ms >= threshold_ms:
-            return 0.0
-        return 1.0 - (avg_latency_ms / threshold_ms)
+def bqaa_score_latency(avg_latency_ms, threshold_ms):
+    if avg_latency_ms <= 0:
+        return 1.0
+    if avg_latency_ms >= threshold_ms:
+        return 0.0
+    return 1.0 - (avg_latency_ms / threshold_ms)
 """;
 
 -- Score tool error rate against a threshold (0.0-1.0).
@@ -146,13 +146,13 @@ OPTIONS (
   description = """Score tool error rate against a threshold (0.0-1.0)."""
 )
 AS r"""
-    def bqaa_score_error_rate(tool_calls, tool_errors, max_error_rate):
-        if tool_calls <= 0:
-            return 1.0
-        rate = tool_errors / tool_calls
-        if rate >= max_error_rate:
-            return 0.0
-        return 1.0 - (rate / max_error_rate)
+def bqaa_score_error_rate(tool_calls, tool_errors, max_error_rate):
+    if tool_calls <= 0:
+        return 1.0
+    rate = tool_errors / tool_calls
+    if rate >= max_error_rate:
+        return 0.0
+    return 1.0 - (rate / max_error_rate)
 """;
 
 -- Score turn count against a maximum (0.0-1.0).
@@ -167,12 +167,12 @@ OPTIONS (
   description = """Score turn count against a maximum (0.0-1.0)."""
 )
 AS r"""
-    def bqaa_score_turn_count(turn_count, max_turns):
-        if turn_count <= 0:
-            return 1.0
-        if turn_count >= max_turns:
-            return 0.0
-        return 1.0 - (turn_count / max_turns)
+def bqaa_score_turn_count(turn_count, max_turns):
+    if turn_count <= 0:
+        return 1.0
+    if turn_count >= max_turns:
+        return 0.0
+    return 1.0 - (turn_count / max_turns)
 """;
 
 -- Score total token usage against a maximum (0.0-1.0).
@@ -187,12 +187,12 @@ OPTIONS (
   description = """Score total token usage against a maximum (0.0-1.0)."""
 )
 AS r"""
-    def bqaa_score_token_efficiency(total_tokens, max_tokens):
-        if total_tokens <= 0:
-            return 1.0
-        if total_tokens >= max_tokens:
-            return 0.0
-        return 1.0 - (total_tokens / max_tokens)
+def bqaa_score_token_efficiency(total_tokens, max_tokens):
+    if total_tokens <= 0:
+        return 1.0
+    if total_tokens >= max_tokens:
+        return 0.0
+    return 1.0 - (total_tokens / max_tokens)
 """;
 
 -- Score average time-to-first-token against a threshold (0.0-1.0).
@@ -207,12 +207,12 @@ OPTIONS (
   description = """Score average time-to-first-token against a threshold (0.0-1.0)."""
 )
 AS r"""
-    def bqaa_score_ttft(avg_ttft_ms, threshold_ms):
-        if avg_ttft_ms <= 0:
-            return 1.0
-        if avg_ttft_ms >= threshold_ms:
-            return 0.0
-        return 1.0 - (avg_ttft_ms / threshold_ms)
+def bqaa_score_ttft(avg_ttft_ms, threshold_ms):
+    if avg_ttft_ms <= 0:
+        return 1.0
+    if avg_ttft_ms >= threshold_ms:
+        return 0.0
+    return 1.0 - (avg_ttft_ms / threshold_ms)
 """;
 
 -- Score estimated session cost against a maximum (0.0-1.0).
@@ -229,13 +229,13 @@ OPTIONS (
   description = """Score estimated session cost against a maximum (0.0-1.0)."""
 )
 AS r"""
-    def bqaa_score_cost(input_tokens, output_tokens, max_cost_usd,
-                        input_cost_per_1k, output_cost_per_1k):
-        cost = ((input_tokens / 1000) * input_cost_per_1k
-                + (output_tokens / 1000) * output_cost_per_1k)
-        if cost <= 0:
-            return 1.0
-        if cost >= max_cost_usd:
-            return 0.0
-        return 1.0 - (cost / max_cost_usd)
+def bqaa_score_cost(input_tokens, output_tokens, max_cost_usd,
+                    input_cost_per_1k, output_cost_per_1k):
+    cost = ((input_tokens / 1000) * input_cost_per_1k
+            + (output_tokens / 1000) * output_cost_per_1k)
+    if cost <= 0:
+        return 1.0
+    if cost >= max_cost_usd:
+        return 0.0
+    return 1.0 - (cost / max_cost_usd)
 """;

--- a/examples/python_udf_event_semantics.sql
+++ b/examples/python_udf_event_semantics.sql
@@ -46,14 +46,14 @@ ORDER BY
 -- 2. Extract agent responses from LLM events                          --
 -- ------------------------------------------------------------------ --
 -- The content column is JSON-typed in the SDK schema.  The UDF expects
--- a plain STRING, so use CAST(content AS STRING) — not TO_JSON_STRING,
--- which would double-encode the payload and break key extraction.
+-- a plain STRING, so use TO_JSON_STRING to convert the JSON value to
+-- its string representation for the Python UDF to parse.
 
 SELECT
   session_id,
   timestamp,
   `PROJECT.UDF_DATASET.bqaa_extract_response_text`(
-    CAST(content AS STRING)
+    TO_JSON_STRING(content)
   ) AS response_text
 FROM
   `PROJECT.DATASET.agent_events`

--- a/src/bigquery_agent_analytics/udf_sql_templates.py
+++ b/src/bigquery_agent_analytics/udf_sql_templates.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import textwrap
-from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -266,8 +265,7 @@ def _render_udf(
     dataset: str,
 ) -> str:
   """Render CREATE OR REPLACE FUNCTION DDL for a single UDF."""
-  # Indent body for the OPTIONS block
-  indented = textwrap.indent(spec.body.rstrip(), "    ")
+  body = spec.body.rstrip()
   return (
       f"-- {spec.description}\n"
       f"CREATE OR REPLACE FUNCTION"
@@ -282,7 +280,7 @@ def _render_udf(
       f'  description = """{spec.description}"""\n'
       f")\n"
       f'AS r"""\n'
-      f"{indented}\n"
+      f"{body}\n"
       f'""";'
   )
 


### PR DESCRIPTION
## Summary
- **(Critical)** Remove `textwrap.indent()` from `_render_udf()` — Python UDF bodies must start at column 0 or BigQuery raises `IndentationError` on every invocation
- **(High)** Replace `CAST(content AS STRING)` with `TO_JSON_STRING(content)` in event semantics example — `CAST` from JSON to STRING is not supported in BigQuery
- **(Low)** Remove unused `from typing import Optional` import from `udf_sql_templates.py`

All 3 bugs were discovered during live E2E testing against `test-project-0728-467323.agent_analytics` (296 rows, 12 sessions). All 9 UDFs now execute correctly.

## Files changed
- `src/bigquery_agent_analytics/udf_sql_templates.py` — fix `_render_udf`, remove unused import
- `deploy/python_udf/register.sql` — fix body indentation to column 0
- `examples/python_udf_event_semantics.sql` — `CAST(content AS STRING)` → `TO_JSON_STRING(content)`

## Test plan
- [x] 906 unit tests pass
- [x] All 9 UDFs registered and invoked successfully in live BigQuery
- [x] Tier 1 (is_error_event, tool_outcome, extract_response_text) validated
- [x] Tier 2 (score_latency, score_error_rate, score_turn_count, score_cost) validated
- [x] Composite queries (error rate per session, pass/fail gate) validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)