### PR TITLE
docs: Hatteras-style categorical evaluation design

### DIFF
--- a/docs/hatteras_evaluation.md
+++ b/docs/hatteras_evaluation.md
@@ -130,6 +130,7 @@ class CategoricalEvaluationConfig(BaseModel):
 
 ```python
 from datetime import datetime
+from datetime import timezone
 from typing import Any, Optional
 
 from pydantic import BaseModel
@@ -161,7 +162,9 @@ class CategoricalEvaluationReport(BaseModel):
     )
     details: dict[str, Any] = Field(default_factory=dict)
     session_results: list[CategoricalSessionResult] = Field(default_factory=list)
-    created_at: datetime
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+    )
 ```
 
 ### New client method
@@ -169,7 +172,7 @@ class CategoricalEvaluationReport(BaseModel):
 ```python
 report = client.evaluate_categorical(
     config=config,
-    filters=TraceFilter(last="24h"),
+    filters=TraceFilter.from_cli_args(last="24h"),
     dataset="agent_events",
 )
 ```


### PR DESCRIPTION
## Summary

- Adds `docs/hatteras_evaluation.md` — a design doc for a new categorical evaluation surface in the SDK
- All models use Pydantic `BaseModel` with `Field()` descriptions, matching SDK conventions (`evaluators.py`, `insights.py`)
- Uses `endpoint` (not `model`) consistently, with config-level endpoint precedence over client defaults
- Includes concrete `AI.GENERATE` SQL template and `output_schema => 'classifications STRING'` decision
- Specifies new module `categorical_evaluator.py` (separate from numeric `evaluators.py`)
- Phase 1 ships a working backend (models + BigQuery-native execution + validation), not models-only
- Open questions 1, 2, and 5 marked as decided with rationale

## Test plan

- [ ] Review doc for internal consistency (field names, phase numbering, open-question status)
- [ ] Verify Python code blocks are syntactically valid
- [ ] Verify SQL template follows SDK patterns (`AI.GENERATE` syntax, `output_schema`)
- [ ] Confirm no stale `model` references remain where `endpoint` is intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)