### PR TITLE
feat: Phase 2 — Gemini API fallback for categorical evaluator

### DIFF
--- a/src/bigquery_agent_analytics/categorical_evaluator.py
+++ b/src/bigquery_agent_analytics/categorical_evaluator.py
@@ -610,23 +610,7 @@ async def classify_sessions_via_api(
             )
         )
   except ImportError:
-    logger.warning(
-        "google-genai not installed, returning parse errors for all sessions."
-    )
-    for sid in transcripts:
-      results.append(
-          CategoricalSessionResult(
-              session_id=sid,
-              metrics=[
-                  CategoricalMetricResult(
-                      metric_name=m.name,
-                      parse_error=True,
-                      passed_validation=False,
-                      raw_response="google-genai not installed",
-                  )
-                  for m in config.metrics
-              ],
-          )
-      )
+    logger.warning("google-genai not installed; cannot run API fallback.")
+    raise
 
   return results

--- a/src/bigquery_agent_analytics/client.py
+++ b/src/bigquery_agent_analytics/client.py
@@ -1230,21 +1230,33 @@ class Client:
       fallback_reason = str(e)
 
     # Fallback: Gemini API.
-    session_results = self._categorical_api_fallback(
-        config,
-        table,
-        where,
-        params,
-        endpoint,
-    )
-    report = build_categorical_report(
-        dataset=f"{table_ref} WHERE {where}",
-        session_results=session_results,
-        config=config,
-    )
-    report.details["execution_mode"] = "api_fallback"
-    report.details["fallback_reason"] = fallback_reason
-    return report
+    try:
+      session_results = self._categorical_api_fallback(
+          config,
+          table,
+          where,
+          params,
+          endpoint,
+      )
+      report = build_categorical_report(
+          dataset=f"{table_ref} WHERE {where}",
+          session_results=session_results,
+          config=config,
+      )
+      report.details["execution_mode"] = "api_fallback"
+      report.details["fallback_reason"] = fallback_reason
+      return report
+    except ImportError:
+      # google-genai not installed — API fallback is unavailable.
+      report = build_categorical_report(
+          dataset=f"{table_ref} WHERE {where}",
+          session_results=[],
+          config=config,
+      )
+      report.details["execution_mode"] = "api_unavailable"
+      report.details["fallback_reason"] = fallback_reason
+      report.details["api_error"] = "google-genai not installed"
+      return report
 
   def _categorical_ai_generate(
       self,

--- a/tests/test_categorical_evaluator.py
+++ b/tests/test_categorical_evaluator.py
@@ -684,16 +684,15 @@ class TestClassifySessionsViaApi:
     # Second session should have parse errors.
     assert all(m.parse_error for m in results[1].metrics)
 
-  def test_import_error_returns_parse_errors(self):
-    """When google-genai is not installed, all sessions should get
-    parse errors."""
+  def test_import_error_propagates(self):
+    """When google-genai is not installed, ImportError should propagate
+    so the caller can set the correct execution mode."""
     config = _make_config()
     transcripts = {"s1": "transcript1"}
 
     import builtins
     import sys
 
-    # Remove google.genai from sys.modules to trigger ImportError.
     saved = {}
     for key in list(sys.modules):
       if key.startswith("google.genai") or key == "google.genai":
@@ -706,14 +705,11 @@ class TestClassifySessionsViaApi:
         raise ImportError("No module named 'google.genai'")
       return original_import(name, *args, **kwargs)
 
-    with patch.object(builtins, "__import__", side_effect=mock_import):
-      results = _run(classify_sessions_via_api(transcripts, config))
+    with pytest.raises(ImportError):
+      with patch.object(builtins, "__import__", side_effect=mock_import):
+        _run(classify_sessions_via_api(transcripts, config))
 
     sys.modules.update(saved)
-
-    assert len(results) == 1
-    assert all(m.parse_error for m in results[0].metrics)
-    assert "google-genai not installed" in results[0].metrics[0].raw_response
 
   def test_case_insensitive_api_response(self):
     """API response with mixed-case categories should normalize."""

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -1263,3 +1263,44 @@ class TestEvaluateCategoricalFallback:
     config = _make_categorical_config()
     report = client.evaluate_categorical(config=config)
     assert "fallback_reason" not in report.details
+
+  def test_api_unavailable_when_genai_not_installed(self):
+    """When AI.GENERATE fails and google-genai is missing, report
+    should have execution_mode='api_unavailable'."""
+    mock_bq = _mock_bq_client()
+
+    call_count = [0]
+
+    def query_side_effect(*args, **kwargs):
+      call_count[0] += 1
+      result = MagicMock()
+      if call_count[0] == 1:
+        result.result.side_effect = Exception("AI.GENERATE not available")
+      else:
+        result.result.return_value = iter(
+            [
+                {"session_id": "s1", "transcript": "USER: Hello"},
+            ]
+        )
+      return result
+
+    mock_bq.query.side_effect = query_side_effect
+
+    client = Client(
+        project_id="proj",
+        dataset_id="ds",
+        verify_schema=False,
+        bq_client=mock_bq,
+    )
+    config = _make_categorical_config()
+
+    with patch(
+        "bigquery_agent_analytics.client.classify_sessions_via_api",
+        side_effect=ImportError("No module named 'google.genai'"),
+    ):
+      report = client.evaluate_categorical(config=config)
+
+    assert report.details["execution_mode"] == "api_unavailable"
+    assert report.details["api_error"] == "google-genai not installed"
+    assert "AI.GENERATE not available" in report.details["fallback_reason"]
+    assert report.total_sessions == 0


### PR DESCRIPTION
## Summary

- Adds Gemini API fallback path for categorical evaluation so it works when BigQuery `AI.GENERATE` is unavailable or fails
- `evaluate_categorical()` now tries `AI.GENERATE` first, catches exceptions, and falls back to the Gemini API — following the same three-tier pattern used by `_evaluate_llm_judge`
- Tracks `execution_mode` (`ai_generate` | `api_fallback`) and `fallback_reason` in `report.details`
- New `classify_sessions_via_api()` async function reuses the same prompt-building and category validation logic as the BQ-native path
- New `CATEGORICAL_TRANSCRIPT_QUERY` fetches session transcripts without `AI.GENERATE` for the fallback path
- Per-session API failures produce parse errors for that session without crashing the run
- Graceful degradation when `google-genai` is not installed

## Test plan

- [x] 14 new tests: API success, per-session failure, ImportError fallback, case normalization, transcript truncation, transcript SQL template, client fallback flow (execution_mode tracking, fallback_reason presence/absence)
- [x] All 995 existing tests pass
- [x] `autoformat.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)