### PR TITLE
feat: Phase 4 — CLI exposure for categorical evaluation

### DIFF
--- a/src/bigquery_agent_analytics/cli.py
+++ b/src/bigquery_agent_analytics/cli.py
@@ -545,10 +545,6 @@ def categorical_eval(
         None,
         help="Model endpoint for classification.",
     ),
-    connection_id: Optional[str] = typer.Option(
-        None,
-        help="BQ connection ID for AI.GENERATE.",
-    ),
     include_justification: bool = typer.Option(
         True,
         help="Include justification in output.",
@@ -589,13 +585,14 @@ def categorical_eval(
           )
           for c in m["categories"]
       ]
-      metrics.append(
-          CategoricalMetricDefinition(
-              name=m["name"],
-              definition=m["definition"],
-              categories=cats,
-          )
-      )
+      metric_kwargs: dict = {
+          "name": m["name"],
+          "definition": m["definition"],
+          "categories": cats,
+      }
+      if "required" in m:
+        metric_kwargs["required"] = m["required"]
+      metrics.append(CategoricalMetricDefinition(**metric_kwargs))
 
     if not metrics:
       typer.echo("Error: no metrics found in metrics file.", err=True)
@@ -626,7 +623,6 @@ def categorical_eval(
         table_id,
         location,
         endpoint=endpoint,
-        connection_id=connection_id,
     )
     report = client.evaluate_categorical(config=config, filters=filters)
     typer.echo(format_output(report, fmt))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1287,6 +1287,43 @@ class TestCategoricalEval:
     assert result.exit_code == 2
 
   @patch("bigquery_agent_analytics.cli._build_client")
+  def test_categorical_eval_required_false_passthrough(
+      self, mock_build, tmp_path
+  ):
+    """Metrics with required=false in JSON should preserve the field."""
+    client = MagicMock()
+    client.evaluate_categorical.return_value = _mock_categorical_report()
+    mock_build.return_value = client
+
+    metrics_with_optional = [
+        {
+            "name": "tone",
+            "definition": "Overall tone.",
+            "required": False,
+            "categories": [
+                {"name": "positive", "definition": "User is satisfied."},
+                {"name": "negative", "definition": "User is frustrated."},
+            ],
+        },
+    ]
+    metrics_path = tmp_path / "metrics.json"
+    metrics_path.write_text(json.dumps(metrics_with_optional))
+
+    result = runner.invoke(
+        app,
+        [
+            "categorical-eval",
+            "--project-id=proj",
+            "--dataset-id=ds",
+            f"--metrics-file={str(metrics_path)}",
+        ],
+    )
+    assert result.exit_code == 0
+    call_kwargs = client.evaluate_categorical.call_args[1]
+    config = call_kwargs["config"]
+    assert config.metrics[0].required is False
+
+  @patch("bigquery_agent_analytics.cli._build_client")
   def test_categorical_eval_empty_metrics_exit_2(self, mock_build, tmp_path):
     metrics_path = tmp_path / "metrics.json"
     metrics_path.write_text("[]")


### PR DESCRIPTION
## Summary
- Add `categorical-eval` CLI command that loads metric definitions from a JSON file and runs `client.evaluate_categorical()`
- Supports all categorical config flags: `--persist`, `--results-table`, `--endpoint`, `--prompt-version`, `--include-justification`
- Standard shared options: `--project-id`, `--dataset-id`, `--table-id`, `--location`, `--agent-id`, `--last`, `--limit`, `--format`
- Metrics file accepts both array format `[{...}]` and dict format `{"metrics": [{...}]}`

## Test plan
- [x] 10 new CLI tests in `TestCategoricalEval` covering JSON output, text format, filter passthrough, persist flags, endpoint override, justification toggle, dict metrics format, error exit codes, missing file, and empty metrics
- [x] All 1020 existing tests pass
- [x] Autoformatted with `autoformat.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)