### PR TITLE
fix: AI.GENERATE SQL escaping + Property Graph PROPERTIES exposure

### DIFF
--- a/docs/ontology_graph_v4_design.md
+++ b/docs/ontology_graph_v4_design.md
@@ -292,16 +292,16 @@ CREATE OR REPLACE PROPERTY GRAPH `project.dataset.YMGO_Context_Graph`
     `project.dataset.decision_points` AS mako_DecisionPoint
       KEY (decision_id, session_id)
       LABEL mako_DecisionPoint
-      PROPERTIES (decision_type, extracted_at),
+      PROPERTIES (decision_id, decision_type, session_id, extracted_at),
     `project.dataset.yahoo_ad_units` AS sup_YahooAdUnit
       KEY (adUnitId, session_id)
       LABEL sup_YahooAdUnit
       LABEL mako_Candidate
-      PROPERTIES (adUnitName, adUnitSize, adUnitPosition, extracted_at),
+      PROPERTIES (adUnitId, adUnitName, adUnitSize, adUnitPosition, session_id, extracted_at),
     `project.dataset.rejection_reasons` AS mako_RejectionReason
       KEY (rejection_id, session_id)
       LABEL mako_RejectionReason
-      PROPERTIES (rejectionType, rejectionRule, extracted_at)
+      PROPERTIES (rejection_id, rejectionType, rejectionRule, session_id, extracted_at)
   )
   EDGE TABLES (
     `project.dataset.candidate_edges` AS CandidateEdge

--- a/examples/ontology_graph_v4_demo.ipynb
+++ b/examples/ontology_graph_v4_demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "id": "a1b2c3d4",
    "metadata": {},
    "outputs": [],
@@ -111,10 +111,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "f6a7b8c9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "!pip install -q bigquery-agent-analytics google-cloud-bigquery pyyaml"
    ]
@@ -129,10 +137,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "b8c9d0e1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Not running in Colab -- using default credentials.\n",
+      "Project  : test-project-0728-467323\n",
+      "Dataset  : agent_analytics\n",
+      "Table    : agent_events\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "\n",
@@ -175,9 +194,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Wrote ymgo_graph_spec.yaml (2984 bytes)\n"
+     ]
+    }
+   ],
    "source": [
     "# Write the YMGO graph spec into the working directory so it is\n",
     "# available regardless of how the notebook was launched (Colab,\n",
@@ -284,10 +311,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "d0e1f2a3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Graph: YMGO_Context_Graph_V3\n",
+      "Entities: ['mako_DecisionPoint', 'sup_YahooAdUnit', 'mako_RejectionReason']\n",
+      "Relationships: ['CandidateEdge', 'ForCandidate']\n"
+     ]
+    }
+   ],
    "source": [
     "from bigquery_agent_analytics.ontology_models import load_graph_spec\n",
     "\n",
@@ -312,10 +349,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "f2a3b4c5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Entity: mako_DecisionPoint\n",
+      "  Keys: primary=['decision_id']\n",
+      "  Properties: ['decision_id', 'decision_type']\n",
+      "  Binding source: test-project-0728-467323.agent_analytics.decision_points\n",
+      "\n",
+      "Entity: sup_YahooAdUnit\n",
+      "  Keys: primary=['adUnitId']\n",
+      "  Properties: ['adUnitId', 'adUnitName', 'adUnitSize', 'adUnitPosition']\n",
+      "  Binding source: test-project-0728-467323.agent_analytics.yahoo_ad_units\n",
+      "\n",
+      "Entity: mako_RejectionReason\n",
+      "  Keys: primary=['rejection_id']\n",
+      "  Properties: ['rejection_id', 'rejectionType', 'rejectionRule']\n",
+      "  Binding source: test-project-0728-467323.agent_analytics.rejection_reasons\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "for entity in spec.entities:\n",
     "    print(f\"Entity: {entity.name}\")\n",
@@ -344,10 +403,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "b4c5d6e7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "=== Extraction Prompt ===\n",
+      "Extract nodes and edges from the agent telemetry below according to the provided ontology.\n",
+      "\n",
+      "Entity types:\n",
+      "  - mako_DecisionPoint \u2014 The atomic unit of decisioning where an agent evaluates alternatives. (properties: decision_id, decision_type)\n",
+      "  - sup_YahooAdUnit \u2014 A specific ad slot on a Yahoo property being evaluated as a candidate. (properties: adUnitId, adUnitName, adUnitSize, adUnitPosition)\n",
+      "  - mako_RejectionReason \u2014 Structured reason why a Candidate was not selected at a DecisionPoint. (properties: rejection_id, rejectionType, rejectionRule)\n",
+      "\n",
+      "=== Output Schema (truncated) ===\n",
+      "\"{\\\"type\\\":\\\"OBJECT\\\",\\\"properties\\\":{\\\"nodes\\\":{\\\"type\\\":\\\"ARRAY\\\",\\\"items\\\":{\\\"type\\\":\\\"OBJECT\\\",\\\"properties\\\":{\\\"entity_name\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"decision_id\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"decision_type\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"adUnitId\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"adUnitName\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"adUnitSize\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"adUnitPosition\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"rejection_id\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"rejectionType\\\":{\\\"type\\\":\\\"STRING\\\"},\\\"rejectionRule\\\":{\\\"type\\\":\\\"STRING\\\"}}}},...\n"
+     ]
+    }
+   ],
    "source": [
     "from bigquery_agent_analytics.ontology_schema_compiler import (\n",
     "    compile_extraction_prompt,\n",
@@ -381,10 +457,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "d6e7f8a9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Extracted 4 nodes, 2 edges\n"
+     ]
+    }
+   ],
    "source": [
     "from bigquery_agent_analytics.ontology_graph import OntologyGraphManager\n",
     "\n",
@@ -396,7 +480,7 @@
     "    endpoint=\"gemini-2.5-flash\",\n",
     ")\n",
     "\n",
-    "SESSION_IDS = [\"YOUR_SESSION_ID_HERE\"]  # Replace with your session IDs\n",
+    "SESSION_IDS = [\"adcp-033c95d7a97d\"]  # Replace with your session IDs\n",
     "\n",
     "graph = extractor.extract_graph(\n",
     "    session_ids=SESSION_IDS,\n",
@@ -407,10 +491,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "e7f8a9b0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  [sup_YahooAdUnit] adcp-033c95d7a97d:sup_YahooAdUnit:adUnitId=Yahoo Homepage\n",
+      "    adUnitId = Yahoo Homepage\n",
+      "    adUnitName = Yahoo Homepage\n",
+      "  [sup_YahooAdUnit] adcp-033c95d7a97d:sup_YahooAdUnit:adUnitId=Yahoo Mail\n",
+      "    adUnitId = Yahoo Mail\n",
+      "    adUnitName = Yahoo Mail\n",
+      "  [mako_DecisionPoint] adcp-033c95d7a97d:mako_DecisionPoint:decision_id=dp_query_homepage_eval\n",
+      "    decision_id = dp_query_homepage_eval\n",
+      "    decision_type = query_ad_inventory\n",
+      "  [mako_DecisionPoint] adcp-033c95d7a97d:mako_DecisionPoint:decision_id=dp_query_mail_eval\n",
+      "    decision_id = dp_query_mail_eval\n",
+      "    decision_type = query_ad_inventory\n"
+     ]
+    }
+   ],
    "source": [
     "for node in graph.nodes[:5]:\n",
     "    print(f\"  [{node.entity_name}] {node.node_id}\")\n",
@@ -435,10 +538,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "a9b0c1d2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Tables created:\n",
+      "  mako_DecisionPoint -> test-project-0728-467323.agent_analytics.decision_points\n",
+      "  sup_YahooAdUnit -> test-project-0728-467323.agent_analytics.yahoo_ad_units\n",
+      "  mako_RejectionReason -> test-project-0728-467323.agent_analytics.rejection_reasons\n",
+      "  CandidateEdge -> test-project-0728-467323.agent_analytics.candidate_edges\n",
+      "  ForCandidate -> test-project-0728-467323.agent_analytics.rejection_mappings\n",
+      "\n",
+      "Rows materialized: {'sup_YahooAdUnit': 2, 'mako_DecisionPoint': 2, 'CandidateEdge': 2}\n"
+     ]
+    }
+   ],
    "source": [
     "from bigquery_agent_analytics.ontology_materializer import OntologyMaterializer\n",
     "\n",
@@ -473,10 +591,71 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "c1d2e3f4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "CREATE OR REPLACE PROPERTY GRAPH `test-project-0728-467323.agent_analytics.YMGO_Context_Graph_V3`\n",
+      "  NODE TABLES (\n",
+      "    `test-project-0728-467323.agent_analytics.decision_points` AS mako_DecisionPoint\n",
+      "      KEY (decision_id, session_id)\n",
+      "      LABEL mako_DecisionPoint\n",
+      "      PROPERTIES (\n",
+      "        decision_id,\n",
+      "        decision_type,\n",
+      "        session_id,\n",
+      "        extracted_at\n",
+      "      ),\n",
+      "    `test-project-0728-467323.agent_analytics.yahoo_ad_units` AS sup_YahooAdUnit\n",
+      "      KEY (adUnitId, session_id)\n",
+      "      LABEL sup_YahooAdUnit\n",
+      "      LABEL mako_Candidate\n",
+      "      PROPERTIES (\n",
+      "        adUnitId,\n",
+      "        adUnitName,\n",
+      "        adUnitSize,\n",
+      "        adUnitPosition,\n",
+      "        session_id,\n",
+      "        extracted_at\n",
+      "      ),\n",
+      "    `test-project-0728-467323.agent_analytics.rejection_reasons` AS mako_RejectionReason\n",
+      "      KEY (rejection_id, session_id)\n",
+      "      LABEL mako_RejectionReason\n",
+      "      PROPERTIES (\n",
+      "        rejection_id,\n",
+      "        rejectionType,\n",
+      "        rejectionRule,\n",
+      "        session_id,\n",
+      "        extracted_at\n",
+      "      )\n",
+      "  )\n",
+      "  EDGE TABLES (\n",
+      "    `test-project-0728-467323.agent_analytics.candidate_edges` AS CandidateEdge\n",
+      "      KEY (decision_id, adUnitId, session_id)\n",
+      "      SOURCE KEY (decision_id, session_id) REFERENCES mako_DecisionPoint (decision_id, session_id)\n",
+      "      DESTINATION KEY (adUnitId, session_id) REFERENCES sup_YahooAdUnit (adUnitId, session_id)\n",
+      "      LABEL CandidateEdge\n",
+      "      PROPERTIES (\n",
+      "        edge_type,\n",
+      "        mako_scoreValue,\n",
+      "        extracted_at\n",
+      "      ),\n",
+      "    `test-project-0728-467323.agent_analytics.rejection_mappings` AS ForCandidate\n",
+      "      KEY (rejection_id, adUnitId, session_id)\n",
+      "      SOURCE KEY (rejection_id, session_id) REFERENCES mako_RejectionReason (rejection_id, session_id)\n",
+      "      DESTINATION KEY (adUnitId, session_id) REFERENCES sup_YahooAdUnit (adUnitId, session_id)\n",
+      "      LABEL ForCandidate\n",
+      "      PROPERTIES (\n",
+      "        extracted_at\n",
+      "      )\n",
+      "  )\n"
+     ]
+    }
+   ],
    "source": [
     "from bigquery_agent_analytics.ontology_property_graph import (\n",
     "    OntologyPropertyGraphCompiler,\n",
@@ -490,10 +669,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "d2e3f4a5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Property Graph created: True\n"
+     ]
+    }
+   ],
    "source": [
     "compiler = OntologyPropertyGraphCompiler(\n",
     "    project_id=PROJECT_ID,\n",
@@ -518,10 +705,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "f4a5b6c7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "=== GQL Showcase Query ===\n",
+      "GRAPH `test-project-0728-467323.agent_analytics.YMGO_Context_Graph_V3`\n",
+      "MATCH\n",
+      "  (dp:mako_DecisionPoint)-[ece:CandidateEdge]->(yau:sup_YahooAdUnit)\n",
+      "WHERE dp.session_id = @session_id\n",
+      "RETURN\n",
+      "  dp.decision_id AS src_decision_id,\n",
+      "  dp.decision_type AS src_decision_type,\n",
+      "  ece.edge_type,\n",
+      "  ece.mako_scoreValue,\n",
+      "  yau.adUnitId AS dst_adUnitId,\n",
+      "  yau.adUnitName AS dst_adUnitName,\n",
+      "  yau.adUnitSize AS dst_adUnitSize,\n",
+      "  yau.adUnitPosition AS dst_adUnitPosition\n",
+      "ORDER BY dp.decision_id\n",
+      "LIMIT @result_limit\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "from bigquery_agent_analytics.ontology_orchestrator import compile_showcase_gql\n",
     "\n",
@@ -532,10 +743,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "a5b6c7d8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Rows returned: 2\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "execution_count": 25,
+     "data": {
+      "text/plain": [
+       "          src_decision_id src_decision_type          edge_type  mako_scoreValue   dst_adUnitId dst_adUnitName dst_adUnitSize dst_adUnitPosition\n",
+       "0  dp_query_homepage_eval  query_ad_inventory  evaluated_candidate          21.06  Yahoo Homepage  Yahoo Homepage           None               None\n",
+       "1     dp_query_mail_eval  query_ad_inventory  evaluated_candidate          36.89     Yahoo Mail     Yahoo Mail           None               None"
+      ],
+      "text/html": [
+       "<div>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n",
+       "      <th></th><th>src_decision_id</th><th>src_decision_type</th><th>edge_type</th><th>mako_scoreValue</th><th>dst_adUnitId</th><th>dst_adUnitName</th><th>dst_adUnitSize</th><th>dst_adUnitPosition</th>\n",
+       "    </tr>\n  </thead>\n  <tbody>\n",
+       "    <tr><th>0</th><td>dp_query_homepage_eval</td><td>query_ad_inventory</td><td>evaluated_candidate</td><td>21.06</td><td>Yahoo Homepage</td><td>Yahoo Homepage</td><td>None</td><td>None</td></tr>\n",
+       "    <tr><th>1</th><td>dp_query_mail_eval</td><td>query_ad_inventory</td><td>evaluated_candidate</td><td>36.89</td><td>Yahoo Mail</td><td>Yahoo Mail</td><td>None</td><td>None</td></tr>\n",
+       "  </tbody>\n</table>\n</div>"
+      ]
+     },
+     "metadata": {}
+    }
+   ],
    "source": [
     "from google.cloud import bigquery\n",
     "\n",
@@ -568,10 +807,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "c7d8e9f0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Graph: YMGO_Context_Graph_V3\n",
+      "Graph ref: test-project-0728-467323.agent_analytics.YMGO_Context_Graph_V3\n",
+      "Nodes: 4\n",
+      "Edges: 2\n",
+      "Tables: ['mako_DecisionPoint', 'sup_YahooAdUnit', 'mako_RejectionReason', 'CandidateEdge', 'ForCandidate']\n",
+      "Rows: {'sup_YahooAdUnit': 2, 'mako_DecisionPoint': 2, 'CandidateEdge': 2}\n",
+      "Property Graph created: True\n"
+     ]
+    }
+   ],
    "source": [
     "from bigquery_agent_analytics.ontology_orchestrator import build_ontology_graph\n",
     "\n",
@@ -605,10 +858,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "e9f0a1b2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Graph: YMGO_Context_Graph_V3\n",
+      "Graph ref: test-project-0728-467323.agent_analytics.YMGO_Context_Graph_V3\n",
+      "Nodes: 4, Edges: 2\n",
+      "Tables: mako_DecisionPoint, sup_YahooAdUnit, mako_RejectionReason, CandidateEdge, ForCandidate\n",
+      "Rows: {'sup_YahooAdUnit': 2, 'mako_DecisionPoint': 2, 'CandidateEdge': 2}\n",
+      "Property Graph created: True\n"
+     ]
+    }
+   ],
    "source": [
     "# Full pipeline\n",
     "!bq-agent-sdk ontology-build \\\n",
@@ -621,10 +887,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "f0a1b2c3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "GRAPH `test-project-0728-467323.agent_analytics.YMGO_Context_Graph_V3`\n",
+      "MATCH\n",
+      "  (dp:mako_DecisionPoint)-[ece:CandidateEdge]->(yau:sup_YahooAdUnit)\n",
+      "WHERE dp.session_id = @session_id\n",
+      "RETURN\n",
+      "  dp.decision_id AS src_decision_id,\n",
+      "  dp.decision_type AS src_decision_type,\n",
+      "  ece.edge_type,\n",
+      "  ece.mako_scoreValue,\n",
+      "  yau.adUnitId AS dst_adUnitId,\n",
+      "  yau.adUnitName AS dst_adUnitName,\n",
+      "  yau.adUnitSize AS dst_adUnitSize,\n",
+      "  yau.adUnitPosition AS dst_adUnitPosition\n",
+      "ORDER BY dp.decision_id\n",
+      "LIMIT @result_limit\n"
+     ]
+    }
+   ],
    "source": [
     "# Generate GQL query\n",
     "!bq-agent-sdk ontology-showcase-gql \\\n",
@@ -654,10 +942,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "b2c3d4e6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\n",
+      "graph:\n",
+      "  name: my_domain_graph\n",
+      "\n",
+      "  entities:\n",
+      "    - name: Customer\n",
+      "      description: \"A customer who places orders.\"\n",
+      "      binding:\n",
+      "        source: \"{{ env }}.customers\"\n",
+      "      keys:\n",
+      "        primary: [customer_id]\n",
+      "      properties:\n",
+      "        - name: customer_id\n",
+      "          type: string\n",
+      "        - name: customer_name\n",
+      "          type: string\n",
+      "        - name: email\n",
+      "          type: string\n",
+      "\n",
+      "    - name: Order\n",
+      "      description: \"A purchase order.\"\n",
+      "      binding:\n",
+      "        source: \"{{ env }}.orders\"\n",
+      "      keys:\n",
+      "        primary: [order_id]\n",
+      "      properties:\n",
+      "        - name: order_id\n",
+      "          type: string\n",
+      "        - name: order_date\n",
+      "          type: string\n",
+      "        - name: total_amount\n",
+      "          type: string\n",
+      "\n",
+      "  relationships:\n",
+      "    - name: Placed\n",
+      "      description: \"Customer placed an order.\"\n",
+      "      from_entity: Customer\n",
+      "      to_entity: Order\n",
+      "      binding:\n",
+      "        source: \"{{ env }}.placed_edges\"\n",
+      "        from_columns: [customer_id]\n",
+      "        to_columns: [order_id]\n",
+      "      properties:\n",
+      "        - name: placed_at\n",
+      "          type: string\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "CUSTOM_SPEC_YAML = \"\"\"\n",
     "graph:\n",
@@ -711,10 +1052,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "c3d4e5f7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Custom spec saved to: my_domain_graph_spec.yaml\n",
+      "Graph: my_domain_graph\n",
+      "Entities: ['Customer', 'Order']\n",
+      "Relationships: ['Placed']\n"
+     ]
+    }
+   ],
    "source": [
     "# Save the custom spec and run the pipeline\n",
     "custom_spec_path = \"my_domain_graph_spec.yaml\"\n",

--- a/src/bigquery_agent_analytics/ontology_graph.py
+++ b/src/bigquery_agent_analytics/ontology_graph.py
@@ -61,6 +61,16 @@ logger = logging.getLogger("bigquery_agent_analytics." + __name__)
 # SQL Templates                                                        #
 # ------------------------------------------------------------------ #
 
+
+def _escape_sql_literal(value: str) -> str:
+  """Escape a Python string for embedding in a BigQuery SQL single-quoted literal.
+
+  Escapes single quotes (``'`` → ``\\'``) and newlines (``\\n`` → ``\\\\n``)
+  so that the resulting SQL string literal is syntactically valid.
+  """
+  return value.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n")
+
+
 _EXTRACT_ONTOLOGY_AI_QUERY = """\
 WITH session_transcripts AS (
   SELECT
@@ -97,8 +107,8 @@ SELECT
           st.transcript
         ),
         endpoint => '{endpoint}',
-        output_schema => '{output_schema}'
-      ).result,
+        output_schema => 'graph_json STRING'
+      ).graph_json,
       r'^```(?:json)?\\s*', ''),
     r'\\s*```$', '')
   AS graph_json
@@ -394,11 +404,11 @@ class OntologyGraphManager:
         The formatted SQL string.
     """
     prompt = compile_extraction_prompt(self.spec)
-    output_schema = compile_output_schema(self.spec)
+    schema_hint = compile_output_schema(self.spec)
+    full_prompt = prompt + "\n\nReturn a single JSON object:\n" + schema_hint
     return _EXTRACT_ONTOLOGY_AI_QUERY.format(
-        prompt=prompt.replace("'", "\\'"),
+        prompt=_escape_sql_literal(full_prompt),
         endpoint=self._resolve_endpoint(),
-        output_schema=output_schema.replace("'", "\\'"),
         project=self.project_id,
         dataset=self.dataset_id,
         table=self.table_id,
@@ -426,12 +436,12 @@ class OntologyGraphManager:
   def _extract_via_ai_generate(self, session_ids: list[str]) -> ExtractedGraph:
     """Server-side extraction using AI.GENERATE with output_schema."""
     prompt = compile_extraction_prompt(self.spec)
-    output_schema = compile_output_schema(self.spec)
+    schema_hint = compile_output_schema(self.spec)
+    full_prompt = prompt + "\n\nReturn a single JSON object:\n" + schema_hint
 
     query = _EXTRACT_ONTOLOGY_AI_QUERY.format(
-        prompt=prompt.replace("'", "\\'"),
+        prompt=_escape_sql_literal(full_prompt),
         endpoint=self._resolve_endpoint(),
-        output_schema=output_schema.replace("'", "\\'"),
         project=self.project_id,
         dataset=self.dataset_id,
         table=self.table_id,

--- a/src/bigquery_agent_analytics/ontology_property_graph.py
+++ b/src/bigquery_agent_analytics/ontology_property_graph.py
@@ -103,12 +103,12 @@ def compile_node_table_clause(
   # Labels: entity may have multiple from extends (label inheritance).
   label_lines = "\n      ".join(f"LABEL {lbl}" for lbl in entity.labels)
 
-  # Properties: all entity property columns except primary keys,
-  # plus metadata columns.  session_id is now in KEY so only
-  # extracted_at goes into PROPERTIES.
-  key_set = set(entity.keys.primary) | {"session_id"}
-  prop_names = [p.name for p in entity.properties if p.name not in key_set]
-  prop_names.append("extracted_at")
+  # Properties: all entity property columns plus session_id and
+  # extracted_at metadata.  BigQuery Property Graph only exposes
+  # columns listed in PROPERTIES to GQL queries — KEY columns are
+  # NOT automatically queryable, so we include everything here.
+  prop_names = [p.name for p in entity.properties]
+  prop_names.extend(["session_id", "extracted_at"])
   props_str = ",\n        ".join(prop_names)
 
   return (

--- a/tests/test_ontology_property_graph.py
+++ b/tests/test_ontology_property_graph.py
@@ -118,10 +118,11 @@ class TestCompileNodeTableClause:
     assert "LABEL Alpha" in clause
     # score is a non-key property.
     assert "score" in clause
-    # Primary key and session_id should NOT be in PROPERTIES.
+    # All columns must appear in PROPERTIES for GQL queryability
+    # (KEY columns are NOT auto-exposed in BQ Property Graph).
     props_section = clause.split("PROPERTIES")[1]
-    assert "alpha_id" not in props_section
-    assert "session_id" not in props_section
+    assert "alpha_id" in props_section
+    assert "session_id" in props_section
     # extracted_at metadata is present.
     assert "extracted_at" in clause
 
@@ -138,12 +139,12 @@ class TestCompileNodeTableClause:
     )
     clause = compile_node_table_clause(entity, "proj", "ds")
     assert "KEY (k1, k2, session_id)" in clause
-    # val should be in PROPERTIES but k1, k2, session_id should not.
+    # All columns must be in PROPERTIES for GQL queryability.
     props_section = clause.split("PROPERTIES")[1]
     assert "val" in props_section
-    assert "k1" not in props_section
-    assert "k2" not in props_section
-    assert "session_id" not in props_section
+    assert "k1" in props_section
+    assert "k2" in props_section
+    assert "session_id" in props_section
 
   def test_multiple_labels(self):
     """Entity with extends gets multiple LABEL lines."""
@@ -192,9 +193,6 @@ class TestCompileEdgeTableClause:
     ) in clause
     assert "LABEL AlphaToBeta" in clause
     assert "weight" in clause
-    # session_id is now in KEY, not in PROPERTIES.
-    props_section = clause.split("PROPERTIES")[1]
-    assert "session_id" not in props_section
     assert "extracted_at" in clause
 
   def test_edge_key_deduplicates_overlapping_columns(self):


### PR DESCRIPTION
## Summary

Three bugs found and fixed during live end-to-end run against real BigQuery with `gemini-2.5-flash`:

- **AI.GENERATE SQL escaping**: Extraction prompt contained literal newlines inside a SQL single-quoted string, causing `Unclosed string literal` errors. Added `_escape_sql_literal()` helper to properly escape `\`, `'`, and `\n` before embedding in SQL.
- **AI.GENERATE output_schema format**: BigQuery now requires SQL-style `output_schema` (e.g., `'graph_json STRING'`) instead of JSON. Updated SQL template and moved JSON schema guidance into the prompt text.
- **Property Graph PROPERTIES exposure**: BigQuery Property Graph KEY columns are not queryable in GQL — they must also appear in `PROPERTIES`. Added all entity property columns (including primary keys and `session_id`) to the PROPERTIES clause so GQL `WHERE`/`RETURN` clauses work.

Also updates notebook with real execution outputs from session `adcp-033c95d7a97d` (4 nodes, 2 edges, GQL returns 2 traversal rows with scores 21.06 and 36.89).

## Test plan

- [x] All 1297 unit tests pass
- [x] `autoformat.sh` clean
- [x] Live e2e: AI.GENERATE extraction succeeds (was failing with SQL syntax error)
- [x] Live e2e: Property Graph DDL executes successfully
- [x] Live e2e: GQL showcase query returns expected results (was failing with "Property not exposed")
- [x] Live e2e: `build_ontology_graph` orchestrator completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)