### PR TITLE
docs: customer-facing V4 design doc + SDK design doc v0.3 update

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -265,7 +265,7 @@ Client(
     project_id: str,              # GCP project
     dataset_id: str,              # BigQuery dataset
     table_id: str = "agent_events",
-    location: str = "us-central1",
+    location: str | None = None,  # BQ location; None lets the client auto-detect
     gcs_bucket_name: str | None,  # For GCS-offloaded payload access
     verify_schema: bool = True,   # Schema validation on init
     endpoint: str | None,         # AI.GENERATE endpoint

--- a/docs/ontology_graph_v4_design.md
+++ b/docs/ontology_graph_v4_design.md
@@ -117,8 +117,11 @@ graph:
   works across dev/staging/prod environments.
 - **Label inheritance** (`extends`) — an entity can carry multiple labels
   in the graph (e.g., `YahooAdUnit` is also a `Candidate`).
-- **Explicit key routing** — `from_columns` / `to_columns` control exactly
-  how edges reference nodes, supporting composite keys.
+- **Explicit key routing** — `from_columns` / `to_columns` define how edge
+  tables reference source and target nodes. For Property Graph compilation,
+  these must exactly match the referenced entity's full primary key;
+  subset bindings are supported for table materialization but will be
+  rejected by the DDL transpiler.
 
 ### Example: Yahoo ADCP Ad Decisioning
 


### PR DESCRIPTION
## Summary

- **Rewrite `ontology_graph_v4_design.md`** as a customer-facing document suitable for sharing with partners (e.g., Yahoo). Replaces internal engineering task lists and phase tracking with architecture diagrams, YAML format reference, SDK/CLI usage examples, generated DDL/GQL examples, and an "Adapt for your own domain" section.
- **Update `design.md`** from v0.1.0 Alpha to v0.3.0, adding all modules delivered since the original design: categorical evaluation, ontology graph (6 modules), CLI, UDF kernels, serialization/formatter. Updates test count to 1297, and rewrites Future Directions to reflect current state.

## Test plan

- [x] Documentation-only changes — no code modified
- [x] All 1297 tests still pass
- [x] V4 design doc reviewed for customer-appropriate language (no internal issue refs, no "Instructions for Engineer" sections, no PR numbers)
- [x] SDK design doc module categorization matches actual `src/` module inventory

🤖 Generated with [Claude Code](https://claude.com/claude-code)