### PR TITLE
feat: add scheduler-based streaming evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,12 @@ build/
 .venv/
 venv/
 env/
+
+# Local workspace metadata
+.code*/
+deploy/streaming_evaluation/.streaming_evaluation_state.json
+
+# macOS Finder metadata
+.DS_Store
+.DS_Store?
+._*

--- a/README.md
+++ b/README.md
@@ -178,6 +178,31 @@ SELECT `my-project.agent_analytics.agent_analytics`(
 See [SDK.md](SDK.md) for the full CLI reference, Remote Function API,
 and continuous query templates.
 
+### Streaming Evaluation
+
+Deploy a dedicated Cloud Run worker that scans recent `agent_events`
+rows every `5` minutes through `Cloud Scheduler -> SDK -> BigQuery`:
+
+```mermaid
+flowchart LR
+  A["agent_events"] --> B["Cloud Scheduler"]
+  B --> C["Cloud Run worker"]
+  C --> D["overlap scan + dedupe + checkpoint"]
+  D --> E["streaming_evaluation_results"]
+```
+
+Quick start:
+
+```bash
+cd deploy/streaming_evaluation
+./setup.sh up my-project my_dataset agent_events us-central1
+```
+
+Use [deploy/streaming_evaluation/README.md](deploy/streaming_evaluation/README.md)
+for the full setup flow. This path intentionally avoids continuous-query
+reservations because they can be too expensive as a default deployment
+mode.
+
 ## Architecture
 
 ```

--- a/deploy/remote_function/dispatch.py
+++ b/deploy/remote_function/dispatch.py
@@ -22,7 +22,6 @@ functions-framework so it can be tested without those dependencies.
 from __future__ import annotations
 
 import json
-import os
 from typing import Any
 
 from bigquery_agent_analytics import Client
@@ -30,40 +29,14 @@ from bigquery_agent_analytics import CodeEvaluator
 from bigquery_agent_analytics import LLMAsJudge
 from bigquery_agent_analytics import serialize
 from bigquery_agent_analytics import TraceFilter
+from bigquery_agent_analytics._deploy_runtime import resolve_client_options
 
 
 def build_client_from_context(
     user_defined_context: dict[str, Any],
 ) -> Client:
   """Build a Client from userDefinedContext + env vars."""
-  udc = user_defined_context
-  project_id = udc.get("project_id", os.environ.get("BQ_AGENT_PROJECT"))
-  dataset_id = udc.get("dataset_id", os.environ.get("BQ_AGENT_DATASET"))
-  table_id = udc.get(
-      "table_id",
-      os.environ.get("BQ_AGENT_TABLE", "agent_events"),
-  )
-  location = udc.get(
-      "location",
-      os.environ.get("BQ_AGENT_LOCATION", "us-central1"),
-  )
-  endpoint = udc.get("endpoint") or os.environ.get("BQ_AGENT_ENDPOINT")
-  connection_id = udc.get("connection_id") or os.environ.get(
-      "BQ_AGENT_CONNECTION_ID"
-  )
-
-  if not project_id or not dataset_id:
-    raise ValueError("project_id and dataset_id required")
-
-  return Client(
-      project_id=project_id,
-      dataset_id=dataset_id,
-      table_id=table_id,
-      location=location,
-      verify_schema=False,
-      endpoint=endpoint,
-      connection_id=connection_id,
-  )
+  return Client(**resolve_client_options(user_defined_context))
 
 
 def process_calls(

--- a/deploy/streaming_evaluation/README.md
+++ b/deploy/streaming_evaluation/README.md
@@ -15,7 +15,7 @@ flowchart LR
 ## What Launches
 
 - terminal rows: `event_type = 'AGENT_COMPLETED'`
-- error rows: `event_type = 'TOOL_ERROR' OR status = 'ERROR' OR error_message IS NOT NULL`
+- error rows: `event_type = 'TOOL_ERROR' OR (status = 'ERROR' AND error_message IS NOT NULL)`
 - evaluator profile: `streaming_observability_v1`
 - default cadence: every `5` minutes
 - default overlap window: `15` minutes
@@ -93,6 +93,16 @@ cd deploy/streaming_evaluation
 `down` deletes the Cloud Scheduler job, removes the Cloud Run service,
 removes the scheduler service account only if this setup created it, and
 deletes the local state file.
+
+`down` intentionally preserves the BigQuery tables:
+
+- `streaming_evaluation_results`
+- `_streaming_eval_state`
+- `_streaming_eval_runs`
+
+This keeps prior evaluation output and internal audit history queryable
+after the deployment is removed. If you want to drop them too, remove
+them manually with `bq rm -t`.
 
 ## Customization
 

--- a/deploy/streaming_evaluation/README.md
+++ b/deploy/streaming_evaluation/README.md
@@ -1,0 +1,114 @@
+# Streaming Evaluation Deployment
+
+This deployment path turns selected recent rows in `agent_events` into
+session-scoped SDK evaluations with a scheduled overlap scan.
+
+```mermaid
+flowchart LR
+  A["agent_events in BigQuery"] --> B["Cloud Scheduler every 5 min"]
+  B --> C["Cloud Run worker"]
+  C --> D["overlap scan + dedupe + checkpoint"]
+  D --> E["SDK evaluate(session_id)"]
+  E --> F["streaming_evaluation_results"]
+```
+
+## What Launches
+
+- terminal rows: `event_type = 'AGENT_COMPLETED'`
+- error rows: `event_type = 'TOOL_ERROR' OR status = 'ERROR' OR error_message IS NOT NULL`
+- evaluator profile: `streaming_observability_v1`
+- default cadence: every `5` minutes
+- default overlap window: `15` minutes
+- default result table: `PROJECT.DATASET.streaming_evaluation_results`
+
+## Why This Path
+
+This launch path intentionally does **not** use BigQuery continuous
+queries.
+
+```mermaid
+flowchart LR
+  A["Continuous query"] --> B["lowest latency"]
+  A --> C["higher fixed cost"]
+  C --> D["can reach the low-thousands per month"]
+  D --> E["not a good default"]
+
+  F["Scheduler + overlap scan"] --> G["lower cost"]
+  F --> H["simpler setup"]
+  F --> I["chosen default"]
+```
+
+## Prerequisites
+
+- `gcloud`, `bq`, and `jq`
+- a BigQuery dataset containing `agent_events`
+- permission to deploy Cloud Run and Cloud Scheduler in the target project
+
+No special BigQuery reservation is required for this deployment path.
+The setup script can enable the required Cloud Run, Cloud Build,
+Artifact Registry, and Cloud Scheduler APIs automatically.
+
+## Quick Start
+
+```bash
+cd deploy/streaming_evaluation
+./setup.sh up rag-chatbot-485501 agent_trace agent_events us-central1
+```
+
+The script will:
+
+- infer the BigQuery dataset location
+- create the result table in the source dataset
+- create hidden checkpoint and run-history tables
+- deploy the `bq-agent-streaming-eval` Cloud Run service
+- create the Cloud Scheduler job that invokes it every `5` minutes
+- print the final result table name and a sample query
+
+After setup, read results directly from BigQuery:
+
+```sql
+SELECT *
+FROM `rag-chatbot-485501.agent_trace.streaming_evaluation_results`
+ORDER BY processed_at DESC
+LIMIT 20;
+```
+
+## Hidden Internal State
+
+The setup path also creates internal tables for recovery and debugging:
+
+- `_streaming_eval_state`
+- `_streaming_eval_runs`
+
+These are implementation details. The primary user-facing table remains
+`streaming_evaluation_results`.
+
+## Cleanup
+
+```bash
+cd deploy/streaming_evaluation
+./setup.sh down
+```
+
+`down` deletes the Cloud Scheduler job, removes the Cloud Run service,
+removes the scheduler service account only if this setup created it, and
+deletes the local state file.
+
+## Customization
+
+Defaults can be overridden with environment variables before running
+`setup.sh`:
+
+- `PROJECT_ID`
+- `DATASET_ID`
+- `SOURCE_TABLE`
+- `RUN_REGION`
+- `RESULT_TABLE`
+- `STATE_TABLE`
+- `RUNS_TABLE`
+- `POLL_SCHEDULE`
+- `OVERLAP_MINUTES`
+- `INITIAL_LOOKBACK_MINUTES`
+
+`RESULT_TABLE` defaults to the same dataset as the source table so the
+result sink stays in the same BigQuery location.

--- a/deploy/streaming_evaluation/README.md
+++ b/deploy/streaming_evaluation/README.md
@@ -52,7 +52,7 @@ Artifact Registry, and Cloud Scheduler APIs automatically.
 
 ```bash
 cd deploy/streaming_evaluation
-./setup.sh up rag-chatbot-485501 agent_trace agent_events us-central1
+./setup.sh up my-project agent_trace agent_events us-central1
 ```
 
 The script will:
@@ -68,7 +68,7 @@ After setup, read results directly from BigQuery:
 
 ```sql
 SELECT *
-FROM `rag-chatbot-485501.agent_trace.streaming_evaluation_results`
+FROM `my-project.agent_trace.streaming_evaluation_results`
 ORDER BY processed_at DESC
 LIMIT 20;
 ```

--- a/deploy/streaming_evaluation/main.py
+++ b/deploy/streaming_evaluation/main.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cloud Run entrypoint for scheduled streaming evaluation."""
+
+from __future__ import annotations
+
+from flask import Flask
+from flask import jsonify
+from flask import request
+
+from worker import handle_scheduled_run
+
+app = Flask(__name__)
+
+
+@app.post("/")
+def handle_request():
+  """HTTP entrypoint for Cloud Scheduler delivery."""
+  body = request.get_json(silent=True)
+  response, status_code = handle_scheduled_run(body or {})
+  return jsonify(response), status_code

--- a/deploy/streaming_evaluation/requirements.txt
+++ b/deploy/streaming_evaluation/requirements.txt
@@ -1,0 +1,7 @@
+flask>=3.0.0
+gunicorn>=22.0.0
+google-cloud-bigquery>=3.0.0
+google-adk>=1.0.0
+pydantic>=2.0.0
+pyyaml>=6.0
+typer>=0.9.0

--- a/deploy/streaming_evaluation/requirements.txt
+++ b/deploy/streaming_evaluation/requirements.txt
@@ -1,7 +1,6 @@
 flask>=3.0.0
 gunicorn>=22.0.0
 google-cloud-bigquery>=3.0.0
-google-adk>=1.0.0
 pydantic>=2.0.0
 pyyaml>=6.0
 typer>=0.9.0

--- a/deploy/streaming_evaluation/setup.sh
+++ b/deploy/streaming_evaluation/setup.sh
@@ -413,13 +413,21 @@ down() {
   local down_region
   local down_service
   local down_job
+  local down_dataset
+  local down_result_table
+  local down_state_table
+  local down_runs_table
   local scheduler_sa_email
   local scheduler_sa_created
 
   down_project="$(jq -r '.project' "$STATE_FILE")"
+  down_dataset="$(jq -r '.dataset' "$STATE_FILE")"
   down_region="$(jq -r '.run_region' "$STATE_FILE")"
   down_service="$(jq -r '.service_name' "$STATE_FILE")"
   down_job="$(jq -r '.scheduler_job_name' "$STATE_FILE")"
+  down_result_table="$(jq -r '.result_table' "$STATE_FILE")"
+  down_state_table="$(jq -r '.state_table' "$STATE_FILE")"
+  down_runs_table="$(jq -r '.runs_table' "$STATE_FILE")"
   scheduler_sa_email="$(jq -r '.scheduler_service_account' "$STATE_FILE")"
   scheduler_sa_created="$(jq -r '.scheduler_service_account_created' "$STATE_FILE")"
 
@@ -440,7 +448,19 @@ down() {
   fi
 
   rm -f "$STATE_FILE"
-  echo "Streaming evaluation scheduler resources removed."
+  cat <<EOF
+Streaming evaluation scheduler resources removed.
+
+BigQuery tables were preserved intentionally:
+  ${down_project}.${down_dataset}.${down_result_table}
+  ${down_project}.${down_dataset}.${down_state_table}
+  ${down_project}.${down_dataset}.${down_runs_table}
+
+To remove them manually:
+  bq rm -t ${down_project}:${down_dataset}.${down_result_table}
+  bq rm -t ${down_project}:${down_dataset}.${down_state_table}
+  bq rm -t ${down_project}:${down_dataset}.${down_runs_table}
+EOF
 }
 
 case "$MODE" in

--- a/deploy/streaming_evaluation/setup.sh
+++ b/deploy/streaming_evaluation/setup.sh
@@ -1,0 +1,397 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+MODE="${1:-}"
+PROJECT="${2:-${PROJECT_ID:-rag-chatbot-485501}}"
+DATASET="${3:-${DATASET_ID:-agent_trace}}"
+SOURCE_TABLE="${4:-${SOURCE_TABLE:-agent_events}}"
+RUN_REGION="${5:-${RUN_REGION:-us-central1}}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+STATE_FILE="${STATE_FILE:-$SCRIPT_DIR/.streaming_evaluation_state.json}"
+
+SERVICE_NAME="${SERVICE_NAME:-bq-agent-streaming-eval}"
+SCHEDULER_JOB_NAME="${SCHEDULER_JOB_NAME:-bq-agent-streaming-eval-5m}"
+SCHEDULER_SA_NAME="${SCHEDULER_SA_NAME:-bq-agent-stream-eval-sa}"
+RESULT_TABLE="${RESULT_TABLE:-streaming_evaluation_results}"
+STATE_TABLE="${STATE_TABLE:-_streaming_eval_state}"
+RUNS_TABLE="${RUNS_TABLE:-_streaming_eval_runs}"
+POLL_SCHEDULE="${POLL_SCHEDULE:-*/5 * * * *}"
+SCHEDULER_TIME_ZONE="${SCHEDULER_TIME_ZONE:-Etc/UTC}"
+OVERLAP_MINUTES="${OVERLAP_MINUTES:-15}"
+INITIAL_LOOKBACK_MINUTES="${INITIAL_LOOKBACK_MINUTES:-30}"
+
+usage() {
+  cat <<EOF
+Usage:
+  ./setup.sh up [PROJECT] [DATASET] [SOURCE_TABLE] [RUN_REGION]
+  ./setup.sh down
+
+Defaults:
+  PROJECT=${PROJECT}
+  DATASET=${DATASET}
+  SOURCE_TABLE=${SOURCE_TABLE}
+  RUN_REGION=${RUN_REGION}
+
+Environment overrides:
+  PROJECT_ID, DATASET_ID, SOURCE_TABLE, RUN_REGION
+  SERVICE_NAME, SCHEDULER_JOB_NAME, SCHEDULER_SA_NAME
+  RESULT_TABLE, STATE_TABLE, RUNS_TABLE
+  POLL_SCHEDULE, SCHEDULER_TIME_ZONE
+  OVERLAP_MINUTES, INITIAL_LOOKBACK_MINUTES
+EOF
+}
+
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required tool: $1" >&2
+    exit 1
+  fi
+}
+
+enable_service_if_needed() {
+  local service="$1"
+  gcloud services enable "$service" \
+    --project="$PROJECT" \
+    --quiet >/dev/null
+}
+
+normalized_scheduler_service_account_name() {
+  local raw="$1"
+  local normalized
+  normalized="$(
+    printf '%s' "$raw" \
+      | tr '[:upper:]' '[:lower:]' \
+      | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
+  )"
+
+  if [[ -z "$normalized" ]]; then
+    normalized="schedsa"
+  fi
+  if [[ ! "$normalized" =~ ^[a-z] ]]; then
+    normalized="a${normalized}"
+  fi
+  normalized="${normalized:0:30}"
+  normalized="${normalized%-}"
+  while [[ ${#normalized} -lt 6 ]]; do
+    normalized="${normalized}0"
+  done
+  echo "$normalized"
+}
+
+infer_bq_location() {
+  bq show --format=json "${PROJECT}:${DATASET}" | jq -r '.location'
+}
+
+create_results_table() {
+  local bq_location="$1"
+  bq query \
+    --project_id="$PROJECT" \
+    --location="$bq_location" \
+    --use_legacy_sql=false \
+    "$(cat <<SQL
+CREATE TABLE IF NOT EXISTS \`${PROJECT}.${DATASET}.${RESULT_TABLE}\` (
+  dedupe_key STRING NOT NULL,
+  session_id STRING NOT NULL,
+  trace_id STRING,
+  span_id STRING,
+  trigger_kind STRING NOT NULL,
+  trigger_event_type STRING NOT NULL,
+  trigger_timestamp TIMESTAMP NOT NULL,
+  is_final BOOL NOT NULL,
+  evaluator_profile STRING NOT NULL,
+  passed BOOL NOT NULL,
+  aggregate_scores_json STRING NOT NULL,
+  details_json STRING NOT NULL,
+  report_json STRING NOT NULL,
+  processed_at TIMESTAMP NOT NULL
+)
+PARTITION BY DATE(processed_at)
+CLUSTER BY trigger_kind, session_id;
+SQL
+)"
+}
+
+create_state_table() {
+  local bq_location="$1"
+  bq query \
+    --project_id="$PROJECT" \
+    --location="$bq_location" \
+    --use_legacy_sql=false \
+    "$(cat <<SQL
+CREATE TABLE IF NOT EXISTS \`${PROJECT}.${DATASET}.${STATE_TABLE}\` (
+  processor_name STRING NOT NULL,
+  checkpoint_timestamp TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+)
+CLUSTER BY processor_name;
+SQL
+)"
+}
+
+create_runs_table() {
+  local bq_location="$1"
+  bq query \
+    --project_id="$PROJECT" \
+    --location="$bq_location" \
+    --use_legacy_sql=false \
+    "$(cat <<SQL
+CREATE TABLE IF NOT EXISTS \`${PROJECT}.${DATASET}.${RUNS_TABLE}\` (
+  processor_name STRING NOT NULL,
+  run_started_at TIMESTAMP NOT NULL,
+  run_finished_at TIMESTAMP NOT NULL,
+  scan_start TIMESTAMP NOT NULL,
+  scan_end TIMESTAMP NOT NULL,
+  trigger_rows_found INT64 NOT NULL,
+  processed_rows INT64 NOT NULL,
+  duplicate_rows INT64 NOT NULL,
+  ignored_rows INT64 NOT NULL,
+  status STRING NOT NULL,
+  error_message STRING
+)
+PARTITION BY DATE(run_started_at)
+CLUSTER BY status, processor_name;
+SQL
+)"
+}
+
+ensure_scheduler_service_account() {
+  local account_id
+  account_id="$(normalized_scheduler_service_account_name "$SCHEDULER_SA_NAME")"
+  local email="${account_id}@${PROJECT}.iam.gserviceaccount.com"
+  if gcloud iam service-accounts describe "$email" \
+    --project="$PROJECT" >/dev/null 2>&1; then
+    echo "${email}|false"
+    return
+  fi
+
+  gcloud iam service-accounts create "$account_id" \
+    --project="$PROJECT" \
+    --display-name="Streaming evaluation scheduler" \
+    >/dev/null
+  echo "${email}|true"
+}
+
+deploy_worker() {
+  local bq_location="$1"
+  local staging
+  staging="$(mktemp -d)"
+
+  cp "$SCRIPT_DIR/main.py" "$SCRIPT_DIR/worker.py" "$staging/"
+  cp -R "$REPO_ROOT/src" "$staging/"
+
+  cat > "$staging/requirements.txt" <<REQS
+flask>=3.0.0
+gunicorn>=22.0.0
+google-cloud-bigquery>=3.0.0
+google-adk>=1.0.0
+pydantic>=2.0.0
+typer>=0.9.0
+REQS
+
+  cat > "$staging/Procfile" <<'PROCFILE'
+web: gunicorn --bind :$PORT --workers 1 --timeout 300 --graceful-timeout 30 main:app
+PROCFILE
+
+  gcloud run deploy "$SERVICE_NAME" \
+    --project="$PROJECT" \
+    --region="$RUN_REGION" \
+    --source="$staging" \
+    --quiet \
+    --no-allow-unauthenticated \
+    --memory=512Mi \
+    --timeout=300 \
+    --concurrency=1 \
+    --min-instances=0 \
+    --max-instances=1 \
+    --set-env-vars="PYTHONPATH=/workspace/src,BQ_AGENT_PROJECT=${PROJECT},BQ_AGENT_DATASET=${DATASET},BQ_AGENT_TABLE=${SOURCE_TABLE},BQ_AGENT_LOCATION=${bq_location},BQ_AGENT_RESULT_PROJECT=${PROJECT},BQ_AGENT_RESULT_DATASET=${DATASET},BQ_AGENT_RESULT_TABLE=${RESULT_TABLE},BQ_AGENT_STATE_PROJECT=${PROJECT},BQ_AGENT_STATE_DATASET=${DATASET},BQ_AGENT_STATE_TABLE=${STATE_TABLE},BQ_AGENT_RUNS_PROJECT=${PROJECT},BQ_AGENT_RUNS_DATASET=${DATASET},BQ_AGENT_RUNS_TABLE=${RUNS_TABLE},BQ_AGENT_OVERLAP_MINUTES=${OVERLAP_MINUTES},BQ_AGENT_INITIAL_LOOKBACK_MINUTES=${INITIAL_LOOKBACK_MINUTES}" \
+    >/dev/null
+
+  rm -rf "$staging"
+}
+
+service_url() {
+  gcloud run services describe "$SERVICE_NAME" \
+    --project="$PROJECT" \
+    --region="$RUN_REGION" \
+    --format='value(status.url)'
+}
+
+ensure_scheduler_job() {
+  local scheduler_sa_email="$1"
+  local url="$2"
+
+  gcloud run services add-iam-policy-binding "$SERVICE_NAME" \
+    --project="$PROJECT" \
+    --region="$RUN_REGION" \
+    --member="serviceAccount:${scheduler_sa_email}" \
+    --role="roles/run.invoker" \
+    --quiet >/dev/null
+
+  if gcloud scheduler jobs describe "$SCHEDULER_JOB_NAME" \
+    --project="$PROJECT" \
+    --location="$RUN_REGION" >/dev/null 2>&1; then
+    gcloud scheduler jobs delete "$SCHEDULER_JOB_NAME" \
+      --project="$PROJECT" \
+      --location="$RUN_REGION" \
+      --quiet >/dev/null
+  fi
+
+  gcloud scheduler jobs create http "$SCHEDULER_JOB_NAME" \
+    --project="$PROJECT" \
+    --location="$RUN_REGION" \
+    --schedule="$POLL_SCHEDULE" \
+    --time-zone="$SCHEDULER_TIME_ZONE" \
+    --uri="${url}/" \
+    --http-method=POST \
+    --headers=Content-Type=application/json \
+    --message-body='{}' \
+    --oidc-service-account-email="$scheduler_sa_email" \
+    --oidc-token-audience="$url" \
+    --attempt-deadline=300s \
+    >/dev/null
+}
+
+write_state() {
+  local bq_location="$1"
+  local scheduler_sa_email="$2"
+  local scheduler_sa_created="$3"
+
+  cat > "$STATE_FILE" <<EOF
+{
+  "project": "${PROJECT}",
+  "dataset": "${DATASET}",
+  "source_table": "${SOURCE_TABLE}",
+  "run_region": "${RUN_REGION}",
+  "bq_location": "${bq_location}",
+  "service_name": "${SERVICE_NAME}",
+  "scheduler_job_name": "${SCHEDULER_JOB_NAME}",
+  "scheduler_service_account": "${scheduler_sa_email}",
+  "scheduler_service_account_created": ${scheduler_sa_created},
+  "result_table": "${RESULT_TABLE}",
+  "state_table": "${STATE_TABLE}",
+  "runs_table": "${RUNS_TABLE}"
+}
+EOF
+}
+
+up() {
+  require_tool jq
+  require_tool bq
+  require_tool gcloud
+
+  enable_service_if_needed run.googleapis.com
+  enable_service_if_needed cloudbuild.googleapis.com
+  enable_service_if_needed artifactregistry.googleapis.com
+  enable_service_if_needed cloudscheduler.googleapis.com
+
+  local bq_location
+  bq_location="$(infer_bq_location)"
+
+  create_results_table "$bq_location"
+  create_state_table "$bq_location"
+  create_runs_table "$bq_location"
+
+  deploy_worker "$bq_location"
+
+  local scheduler_sa_result
+  scheduler_sa_result="$(ensure_scheduler_service_account)"
+  local scheduler_sa_email="${scheduler_sa_result%%|*}"
+  local scheduler_sa_created="${scheduler_sa_result##*|}"
+
+  local url
+  url="$(service_url)"
+  ensure_scheduler_job "$scheduler_sa_email" "$url"
+
+  write_state "$bq_location" "$scheduler_sa_email" "$scheduler_sa_created"
+
+  cat <<EOF
+Streaming evaluation scheduler deployed.
+
+Cloud Run service:
+  ${SERVICE_NAME}
+
+Cloud Scheduler job:
+  ${SCHEDULER_JOB_NAME}
+
+Result table:
+  ${PROJECT}.${DATASET}.${RESULT_TABLE}
+
+Sample query:
+  SELECT *
+  FROM \`${PROJECT}.${DATASET}.${RESULT_TABLE}\`
+  ORDER BY processed_at DESC
+  LIMIT 20;
+EOF
+}
+
+down() {
+  require_tool jq
+  require_tool gcloud
+
+  if [[ ! -f "$STATE_FILE" ]]; then
+    echo "State file not found: $STATE_FILE" >&2
+    exit 1
+  fi
+
+  local down_project
+  local down_region
+  local down_service
+  local down_job
+  local scheduler_sa_email
+  local scheduler_sa_created
+
+  down_project="$(jq -r '.project' "$STATE_FILE")"
+  down_region="$(jq -r '.run_region' "$STATE_FILE")"
+  down_service="$(jq -r '.service_name' "$STATE_FILE")"
+  down_job="$(jq -r '.scheduler_job_name' "$STATE_FILE")"
+  scheduler_sa_email="$(jq -r '.scheduler_service_account' "$STATE_FILE")"
+  scheduler_sa_created="$(jq -r '.scheduler_service_account_created' "$STATE_FILE")"
+
+  gcloud scheduler jobs delete "$down_job" \
+    --project="$down_project" \
+    --location="$down_region" \
+    --quiet >/dev/null 2>&1 || true
+
+  gcloud run services delete "$down_service" \
+    --project="$down_project" \
+    --region="$down_region" \
+    --quiet >/dev/null 2>&1 || true
+
+  if [[ "$scheduler_sa_created" == "true" ]]; then
+    gcloud iam service-accounts delete "$scheduler_sa_email" \
+      --project="$down_project" \
+      --quiet >/dev/null 2>&1 || true
+  fi
+
+  rm -f "$STATE_FILE"
+  echo "Streaming evaluation scheduler resources removed."
+}
+
+case "$MODE" in
+  up)
+    up
+    ;;
+  down)
+    down
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/deploy/streaming_evaluation/setup.sh
+++ b/deploy/streaming_evaluation/setup.sh
@@ -239,6 +239,7 @@ deploy_worker() {
   local bq_location="$1"
   local staging
   staging="$(mktemp -d)"
+  trap 'rm -rf "$staging"' RETURN
 
   cp "$SCRIPT_DIR/main.py" "$SCRIPT_DIR/worker.py" "$staging/"
   cp "$SCRIPT_DIR/requirements.txt" "$staging/"
@@ -261,8 +262,6 @@ PROCFILE
     --max-instances=1 \
     --set-env-vars="PYTHONPATH=/workspace/src,BQ_AGENT_PROJECT=${PROJECT},BQ_AGENT_DATASET=${DATASET},BQ_AGENT_TABLE=${SOURCE_TABLE},BQ_AGENT_LOCATION=${bq_location},BQ_AGENT_RESULT_PROJECT=${PROJECT},BQ_AGENT_RESULT_DATASET=${DATASET},BQ_AGENT_RESULT_TABLE=${RESULT_TABLE},BQ_AGENT_STATE_PROJECT=${PROJECT},BQ_AGENT_STATE_DATASET=${DATASET},BQ_AGENT_STATE_TABLE=${STATE_TABLE},BQ_AGENT_RUNS_PROJECT=${PROJECT},BQ_AGENT_RUNS_DATASET=${DATASET},BQ_AGENT_RUNS_TABLE=${RUNS_TABLE},BQ_AGENT_OVERLAP_MINUTES=${OVERLAP_MINUTES},BQ_AGENT_INITIAL_LOOKBACK_MINUTES=${INITIAL_LOOKBACK_MINUTES}" \
     >/dev/null
-
-  rm -rf "$staging"
 }
 
 service_url() {
@@ -374,11 +373,10 @@ up() {
   local scheduler_sa_created="${scheduler_sa_result##*|}"
   ensure_scheduler_oidc_binding "$scheduler_sa_email"
 
-  write_state "$bq_location" "$scheduler_sa_email" "$scheduler_sa_created"
-
   local url
   url="$(service_url)"
   ensure_scheduler_job "$scheduler_sa_email" "$url"
+  write_state "$bq_location" "$scheduler_sa_email" "$scheduler_sa_created"
 
   cat <<EOF
 Streaming evaluation scheduler deployed.

--- a/deploy/streaming_evaluation/setup.sh
+++ b/deploy/streaming_evaluation/setup.sh
@@ -16,8 +16,8 @@
 set -euo pipefail
 
 MODE="${1:-}"
-PROJECT="${2:-${PROJECT_ID:-rag-chatbot-485501}}"
-DATASET="${3:-${DATASET_ID:-agent_trace}}"
+PROJECT="${2:-${PROJECT_ID:-}}"
+DATASET="${3:-${DATASET_ID:-}}"
 SOURCE_TABLE="${4:-${SOURCE_TABLE:-agent_events}}"
 RUN_REGION="${5:-${RUN_REGION:-us-central1}}"
 
@@ -39,12 +39,14 @@ INITIAL_LOOKBACK_MINUTES="${INITIAL_LOOKBACK_MINUTES:-30}"
 usage() {
   cat <<EOF
 Usage:
-  ./setup.sh up [PROJECT] [DATASET] [SOURCE_TABLE] [RUN_REGION]
+  ./setup.sh up PROJECT DATASET [SOURCE_TABLE] [RUN_REGION]
   ./setup.sh down
 
-Defaults:
-  PROJECT=${PROJECT}
-  DATASET=${DATASET}
+Required for "up":
+  PROJECT or PROJECT_ID
+  DATASET or DATASET_ID
+
+Defaults for optional "up" arguments:
   SOURCE_TABLE=${SOURCE_TABLE}
   RUN_REGION=${RUN_REGION}
 
@@ -55,6 +57,19 @@ Environment overrides:
   POLL_SCHEDULE, SCHEDULER_TIME_ZONE
   OVERLAP_MINUTES, INITIAL_LOOKBACK_MINUTES
 EOF
+}
+
+require_up_inputs() {
+  if [[ -z "$PROJECT" || -z "$DATASET" ]]; then
+    cat >&2 <<EOF
+PROJECT and DATASET are required for "up".
+
+Examples:
+  ./setup.sh up my-project agent_trace agent_events us-central1
+  PROJECT_ID=my-project DATASET_ID=agent_trace ./setup.sh up
+EOF
+    exit 1
+  fi
 }
 
 require_tool() {
@@ -184,7 +199,40 @@ ensure_scheduler_service_account() {
     --project="$PROJECT" \
     --display-name="Streaming evaluation scheduler" \
     >/dev/null
+  wait_for_service_account "$email"
   echo "${email}|true"
+}
+
+wait_for_service_account() {
+  local scheduler_sa_email="$1"
+  local attempt
+
+  for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    if gcloud iam service-accounts describe "$scheduler_sa_email" \
+      --project="$PROJECT" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 5
+  done
+
+  echo "Service account did not become visible in IAM: ${scheduler_sa_email}" >&2
+  return 1
+}
+
+ensure_scheduler_oidc_binding() {
+  local scheduler_sa_email="$1"
+  local project_number
+  local scheduler_service_agent
+
+  wait_for_service_account "$scheduler_sa_email"
+  project_number="$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')"
+  scheduler_service_agent="service-${project_number}@gcp-sa-cloudscheduler.iam.gserviceaccount.com"
+
+  gcloud iam service-accounts add-iam-policy-binding "$scheduler_sa_email" \
+    --project="$PROJECT" \
+    --member="serviceAccount:${scheduler_service_agent}" \
+    --role="roles/iam.serviceAccountOpenIdTokenCreator" \
+    --quiet >/dev/null
 }
 
 deploy_worker() {
@@ -193,16 +241,8 @@ deploy_worker() {
   staging="$(mktemp -d)"
 
   cp "$SCRIPT_DIR/main.py" "$SCRIPT_DIR/worker.py" "$staging/"
+  cp "$SCRIPT_DIR/requirements.txt" "$staging/"
   cp -R "$REPO_ROOT/src" "$staging/"
-
-  cat > "$staging/requirements.txt" <<REQS
-flask>=3.0.0
-gunicorn>=22.0.0
-google-cloud-bigquery>=3.0.0
-google-adk>=1.0.0
-pydantic>=2.0.0
-typer>=0.9.0
-REQS
 
   cat > "$staging/Procfile" <<'PROCFILE'
 web: gunicorn --bind :$PORT --workers 1 --timeout 300 --graceful-timeout 30 main:app
@@ -235,7 +275,11 @@ service_url() {
 ensure_scheduler_job() {
   local scheduler_sa_email="$1"
   local url="$2"
+  local error_file
+  local error_output
+  local attempt
 
+  wait_for_service_account "$scheduler_sa_email"
   gcloud run services add-iam-policy-binding "$SERVICE_NAME" \
     --project="$PROJECT" \
     --region="$RUN_REGION" \
@@ -252,19 +296,33 @@ ensure_scheduler_job() {
       --quiet >/dev/null
   fi
 
-  gcloud scheduler jobs create http "$SCHEDULER_JOB_NAME" \
-    --project="$PROJECT" \
-    --location="$RUN_REGION" \
-    --schedule="$POLL_SCHEDULE" \
-    --time-zone="$SCHEDULER_TIME_ZONE" \
-    --uri="${url}/" \
-    --http-method=POST \
-    --headers=Content-Type=application/json \
-    --message-body='{}' \
-    --oidc-service-account-email="$scheduler_sa_email" \
-    --oidc-token-audience="$url" \
-    --attempt-deadline=300s \
-    >/dev/null
+  error_file="$(mktemp)"
+  for attempt in 1 2 3 4 5; do
+    if gcloud scheduler jobs create http "$SCHEDULER_JOB_NAME" \
+      --project="$PROJECT" \
+      --location="$RUN_REGION" \
+      --schedule="$POLL_SCHEDULE" \
+      --time-zone="$SCHEDULER_TIME_ZONE" \
+      --uri="${url}/" \
+      --http-method=POST \
+      --headers=Content-Type=application/json \
+      --message-body='{}' \
+      --oidc-service-account-email="$scheduler_sa_email" \
+      --oidc-token-audience="$url" \
+      --attempt-deadline=300s \
+      >/dev/null 2>"$error_file"; then
+      rm -f "$error_file"
+      return
+    fi
+
+    error_output="$(cat "$error_file")"
+    if [[ "$error_output" != *"NOT_FOUND"* || "$attempt" -eq 5 ]]; then
+      rm -f "$error_file"
+      echo "$error_output" >&2
+      return 1
+    fi
+    sleep 5
+  done
 }
 
 write_state() {
@@ -294,6 +352,7 @@ up() {
   require_tool jq
   require_tool bq
   require_tool gcloud
+  require_up_inputs
 
   enable_service_if_needed run.googleapis.com
   enable_service_if_needed cloudbuild.googleapis.com
@@ -313,12 +372,13 @@ up() {
   scheduler_sa_result="$(ensure_scheduler_service_account)"
   local scheduler_sa_email="${scheduler_sa_result%%|*}"
   local scheduler_sa_created="${scheduler_sa_result##*|}"
+  ensure_scheduler_oidc_binding "$scheduler_sa_email"
+
+  write_state "$bq_location" "$scheduler_sa_email" "$scheduler_sa_created"
 
   local url
   url="$(service_url)"
   ensure_scheduler_job "$scheduler_sa_email" "$url"
-
-  write_state "$bq_location" "$scheduler_sa_email" "$scheduler_sa_created"
 
   cat <<EOF
 Streaming evaluation scheduler deployed.

--- a/deploy/streaming_evaluation/trigger_query.sql
+++ b/deploy/streaming_evaluation/trigger_query.sql
@@ -1,0 +1,32 @@
+-- Scheduled overlap scan: agent_events -> streaming evaluation worker
+--
+-- Placeholders:
+--   PROJECT      - GCP project id
+--   DATASET      - BigQuery dataset id
+--   SOURCE_TABLE - source table to scan
+--   SCAN_START   - overlap window lower bound (TIMESTAMP literal or parameter)
+--   SCAN_END     - overlap window upper bound (TIMESTAMP literal or parameter)
+
+SELECT
+  session_id,
+  trace_id,
+  span_id,
+  event_type,
+  status,
+  error_message,
+  timestamp AS trigger_timestamp,
+  CASE
+    WHEN event_type = 'AGENT_COMPLETED' THEN 'session_terminal'
+    ELSE 'error_event'
+  END AS trigger_kind
+FROM `PROJECT.DATASET.SOURCE_TABLE`
+WHERE timestamp >= SCAN_START
+  AND timestamp < SCAN_END
+  AND session_id IS NOT NULL
+  AND (
+    event_type = 'AGENT_COMPLETED'
+    OR event_type = 'TOOL_ERROR'
+    OR status = 'ERROR'
+    OR error_message IS NOT NULL
+  )
+ORDER BY trigger_timestamp ASC;

--- a/deploy/streaming_evaluation/trigger_query.sql
+++ b/deploy/streaming_evaluation/trigger_query.sql
@@ -26,7 +26,9 @@ WHERE timestamp >= SCAN_START
   AND (
     event_type = 'AGENT_COMPLETED'
     OR event_type = 'TOOL_ERROR'
-    OR status = 'ERROR'
-    OR error_message IS NOT NULL
+    OR (
+      status = 'ERROR'
+      AND error_message IS NOT NULL
+    )
   )
 ORDER BY trigger_timestamp ASC;

--- a/deploy/streaming_evaluation/worker.py
+++ b/deploy/streaming_evaluation/worker.py
@@ -236,6 +236,7 @@ def handle_scheduled_run(
   config = None
   scan_start = None
   stats = RunStats()
+  success_history_written = False
 
   try:
     client = build_client_from_context({})
@@ -251,6 +252,9 @@ def handle_scheduled_run(
 
     for trigger in iter_triggers(client, config, scan_start, run_started_at):
       stats.trigger_rows_found += 1
+      if isinstance(trigger, _IgnoredTrigger):
+        stats.ignored_rows += 1
+        continue
       if not trigger.session_id:
         logger.warning("Ignoring trigger row without session_id")
         stats.ignored_rows += 1
@@ -275,7 +279,6 @@ def handle_scheduled_run(
       else:
         stats.duplicate_rows += 1
 
-    update_checkpoint(client, config, run_started_at)
     write_run_history(
         client=client,
         config=config,
@@ -287,9 +290,15 @@ def handle_scheduled_run(
         status="success",
         error_message=None,
     )
+    success_history_written = True
+    update_checkpoint(client, config, run_started_at)
   except Exception as exc:  # pragma: no cover - exercised in tests
     logger.exception("Scheduled streaming evaluation run failed")
-    if client is not None and config is not None:
+    if (
+        client is not None
+        and config is not None
+        and not success_history_written
+    ):
       try:
         write_run_history(
             client=client,

--- a/deploy/streaming_evaluation/worker.py
+++ b/deploy/streaming_evaluation/worker.py
@@ -164,33 +164,62 @@ WHEN NOT MATCHED THEN
   )
 """
 
-_RUNS_INSERT_QUERY = """\
-INSERT INTO `{project}.{dataset}.{table}` (
-  processor_name,
-  run_started_at,
-  run_finished_at,
-  scan_start,
-  scan_end,
-  trigger_rows_found,
-  processed_rows,
-  duplicate_rows,
-  ignored_rows,
-  status,
-  error_message
-)
-VALUES (
-  @processor_name,
-  @run_started_at,
-  @run_finished_at,
-  @scan_start,
-  @scan_end,
-  @trigger_rows_found,
-  @processed_rows,
-  @duplicate_rows,
-  @ignored_rows,
-  @status,
-  @error_message
-)
+_RUNS_MERGE_QUERY = """\
+MERGE `{project}.{dataset}.{table}` T
+USING (
+  SELECT
+    @processor_name AS processor_name,
+    @run_started_at AS run_started_at,
+    @run_finished_at AS run_finished_at,
+    @scan_start AS scan_start,
+    @scan_end AS scan_end,
+    @trigger_rows_found AS trigger_rows_found,
+    @processed_rows AS processed_rows,
+    @duplicate_rows AS duplicate_rows,
+    @ignored_rows AS ignored_rows,
+    @status AS status,
+    @error_message AS error_message
+) S
+ON T.processor_name = S.processor_name
+  AND T.run_started_at = S.run_started_at
+WHEN MATCHED THEN
+  UPDATE SET
+    run_finished_at = S.run_finished_at,
+    scan_start = S.scan_start,
+    scan_end = S.scan_end,
+    trigger_rows_found = S.trigger_rows_found,
+    processed_rows = S.processed_rows,
+    duplicate_rows = S.duplicate_rows,
+    ignored_rows = S.ignored_rows,
+    status = S.status,
+    error_message = S.error_message
+WHEN NOT MATCHED THEN
+  INSERT (
+    processor_name,
+    run_started_at,
+    run_finished_at,
+    scan_start,
+    scan_end,
+    trigger_rows_found,
+    processed_rows,
+    duplicate_rows,
+    ignored_rows,
+    status,
+    error_message
+  )
+  VALUES (
+    S.processor_name,
+    S.run_started_at,
+    S.run_finished_at,
+    S.scan_start,
+    S.scan_end,
+    S.trigger_rows_found,
+    S.processed_rows,
+    S.duplicate_rows,
+    S.ignored_rows,
+    S.status,
+    S.error_message
+  )
 """
 
 
@@ -238,7 +267,7 @@ def handle_scheduled_run(
   config = None
   scan_start = None
   stats = RunStats()
-  success_history_written = False
+  success_run_finalized = False
 
   try:
     client = build_client_from_context({})
@@ -295,15 +324,11 @@ def handle_scheduled_run(
         status="success",
         error_message=None,
     )
-    success_history_written = True
     update_checkpoint(client, config, run_started_at)
+    success_run_finalized = True
   except Exception as exc:  # pragma: no cover - exercised in tests
     logger.exception("Scheduled streaming evaluation run failed")
-    if (
-        client is not None
-        and config is not None
-        and not success_history_written
-    ):
+    if client is not None and config is not None and not success_run_finalized:
       try:
         write_run_history(
             client=client,
@@ -318,7 +343,7 @@ def handle_scheduled_run(
         )
       except Exception:  # pragma: no cover - defensive
         logger.exception("Failed to persist streaming run history")
-    return {"status": "retry", "reason": str(exc)}, 500
+    return {"status": "retry", "reason": "internal error"}, 500
 
   return {
       "status": "processed",
@@ -340,7 +365,9 @@ def load_runtime_config(client) -> RuntimeConfig:
 
   result_project = os.environ.get("BQ_AGENT_RESULT_PROJECT", source_project)
   result_dataset = os.environ.get("BQ_AGENT_RESULT_DATASET", source_dataset)
-  result_table = os.environ.get("BQ_AGENT_RESULT_TABLE", STREAMING_RESULTS_TABLE)
+  result_table = os.environ.get(
+      "BQ_AGENT_RESULT_TABLE", STREAMING_RESULTS_TABLE
+  )
 
   state_project = os.environ.get("BQ_AGENT_STATE_PROJECT", result_project)
   state_dataset = os.environ.get("BQ_AGENT_STATE_DATASET", result_dataset)
@@ -381,7 +408,9 @@ def load_runtime_config(client) -> RuntimeConfig:
   )
 
 
-def iter_triggers(client, config: RuntimeConfig, scan_start: datetime, scan_end: datetime):
+def iter_triggers(
+    client, config: RuntimeConfig, scan_start: datetime, scan_end: datetime
+):
   """Yield normalized triggers from the overlap scan query."""
   query = _TRIGGER_SCAN_QUERY.format(
       project=config.source_project,
@@ -440,8 +469,12 @@ def persist_result_row(
   )
   job_config = bigquery.QueryJobConfig(
       query_parameters=[
-          bigquery.ScalarQueryParameter("dedupe_key", "STRING", row["dedupe_key"]),
-          bigquery.ScalarQueryParameter("session_id", "STRING", row["session_id"]),
+          bigquery.ScalarQueryParameter(
+              "dedupe_key", "STRING", row["dedupe_key"]
+          ),
+          bigquery.ScalarQueryParameter(
+              "session_id", "STRING", row["session_id"]
+          ),
           bigquery.ScalarQueryParameter("trace_id", "STRING", row["trace_id"]),
           bigquery.ScalarQueryParameter("span_id", "STRING", row["span_id"]),
           bigquery.ScalarQueryParameter(
@@ -476,7 +509,9 @@ def persist_result_row(
               "STRING",
               row["details_json"],
           ),
-          bigquery.ScalarQueryParameter("report_json", "STRING", row["report_json"]),
+          bigquery.ScalarQueryParameter(
+              "report_json", "STRING", row["report_json"]
+          ),
           bigquery.ScalarQueryParameter(
               "processed_at",
               "TIMESTAMP",
@@ -487,7 +522,15 @@ def persist_result_row(
 
   job = client.bq_client.query(query, job_config=job_config)
   job.result()
-  return bool(getattr(job, "num_dml_affected_rows", 0))
+  affected_rows = getattr(job, "num_dml_affected_rows", None)
+  if affected_rows is None:
+    logger.warning(
+        "BigQuery DML stats were unavailable for dedupe_key=%s; "
+        "treating the row as processed",
+        row["dedupe_key"],
+    )
+    return True
+  return bool(affected_rows)
 
 
 def update_checkpoint(
@@ -535,7 +578,7 @@ def write_run_history(
     error_message: str | None,
 ) -> None:
   """Write hidden run metadata for debugging and recovery analysis."""
-  query = _RUNS_INSERT_QUERY.format(
+  query = _RUNS_MERGE_QUERY.format(
       project=config.runs_project,
       dataset=config.runs_dataset,
       table=config.runs_table,
@@ -574,9 +617,13 @@ def write_run_history(
               "INT64",
               stats.duplicate_rows,
           ),
-          bigquery.ScalarQueryParameter("ignored_rows", "INT64", stats.ignored_rows),
+          bigquery.ScalarQueryParameter(
+              "ignored_rows", "INT64", stats.ignored_rows
+          ),
           bigquery.ScalarQueryParameter("status", "STRING", status),
-          bigquery.ScalarQueryParameter("error_message", "STRING", error_message),
+          bigquery.ScalarQueryParameter(
+              "error_message", "STRING", error_message
+          ),
       ]
   )
   client.bq_client.query(query, job_config=job_config).result()
@@ -601,8 +648,17 @@ def _row_to_dict(row: Any) -> dict[str, Any]:
 
 
 def _env_int(name: str, default: int) -> int:
-  """Read an integer env var with a strict fallback."""
+  """Read an integer env var with a warning fallback."""
   raw = os.environ.get(name)
   if raw is None:
     return default
-  return int(raw)
+  try:
+    return int(raw)
+  except ValueError:
+    logger.warning(
+        "Invalid integer value for %s=%r; using default %s",
+        name,
+        raw,
+        default,
+    )
+    return default

--- a/deploy/streaming_evaluation/worker.py
+++ b/deploy/streaming_evaluation/worker.py
@@ -1,0 +1,594 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scheduled streaming evaluation worker logic.
+
+This module keeps Cloud Scheduler request handling, overlap-window
+scanning, SDK execution, and BigQuery persistence independent of Flask
+so the Cloud Run entrypoint can stay thin and the behavior can be unit
+tested without a live server.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+import logging
+import os
+from typing import Any
+
+from google.cloud import bigquery
+
+from bigquery_agent_analytics import TraceFilter
+from bigquery_agent_analytics._deploy_runtime import build_client_from_context
+from bigquery_agent_analytics._deploy_runtime import resolve_client_options
+from bigquery_agent_analytics._streaming_evaluation import build_streaming_observability_evaluator
+from bigquery_agent_analytics._streaming_evaluation import compute_scan_start
+from bigquery_agent_analytics._streaming_evaluation import DEFAULT_INITIAL_LOOKBACK_MINUTES
+from bigquery_agent_analytics._streaming_evaluation import DEFAULT_OVERLAP_MINUTES
+from bigquery_agent_analytics._streaming_evaluation import parse_trigger_row
+from bigquery_agent_analytics._streaming_evaluation import serialize_streaming_result_row
+from bigquery_agent_analytics._streaming_evaluation import STREAMING_PROCESSOR_NAME
+from bigquery_agent_analytics._streaming_evaluation import STREAMING_RESULTS_TABLE
+from bigquery_agent_analytics._streaming_evaluation import STREAMING_RUNS_TABLE
+from bigquery_agent_analytics._streaming_evaluation import STREAMING_STATE_TABLE
+
+logger = logging.getLogger("bigquery_agent_analytics." + __name__)
+
+_TRIGGER_SCAN_QUERY = """\
+SELECT
+  session_id,
+  trace_id,
+  span_id,
+  event_type,
+  status,
+  error_message,
+  timestamp AS trigger_timestamp,
+  CASE
+    WHEN event_type = 'AGENT_COMPLETED' THEN 'session_terminal'
+    ELSE 'error_event'
+  END AS trigger_kind
+FROM `{project}.{dataset}.{table}`
+WHERE timestamp >= @scan_start
+  AND timestamp < @scan_end
+  AND session_id IS NOT NULL
+  AND (
+    event_type = 'AGENT_COMPLETED'
+    OR event_type = 'TOOL_ERROR'
+    OR status = 'ERROR'
+    OR error_message IS NOT NULL
+  )
+ORDER BY trigger_timestamp ASC
+"""
+
+_RESULTS_MERGE_QUERY = """\
+MERGE `{project}.{dataset}.{table}` T
+USING (
+  SELECT
+    @dedupe_key AS dedupe_key,
+    @session_id AS session_id,
+    @trace_id AS trace_id,
+    @span_id AS span_id,
+    @trigger_kind AS trigger_kind,
+    @trigger_event_type AS trigger_event_type,
+    @trigger_timestamp AS trigger_timestamp,
+    @is_final AS is_final,
+    @evaluator_profile AS evaluator_profile,
+    @passed AS passed,
+    @aggregate_scores_json AS aggregate_scores_json,
+    @details_json AS details_json,
+    @report_json AS report_json,
+    @processed_at AS processed_at
+) S
+ON T.dedupe_key = S.dedupe_key
+WHEN NOT MATCHED THEN
+  INSERT (
+    dedupe_key,
+    session_id,
+    trace_id,
+    span_id,
+    trigger_kind,
+    trigger_event_type,
+    trigger_timestamp,
+    is_final,
+    evaluator_profile,
+    passed,
+    aggregate_scores_json,
+    details_json,
+    report_json,
+    processed_at
+  )
+  VALUES (
+    S.dedupe_key,
+    S.session_id,
+    S.trace_id,
+    S.span_id,
+    S.trigger_kind,
+    S.trigger_event_type,
+    S.trigger_timestamp,
+    S.is_final,
+    S.evaluator_profile,
+    S.passed,
+    S.aggregate_scores_json,
+    S.details_json,
+    S.report_json,
+    S.processed_at
+  )
+"""
+
+_LOAD_STATE_QUERY = """\
+SELECT checkpoint_timestamp
+FROM `{project}.{dataset}.{table}`
+WHERE processor_name = @processor_name
+LIMIT 1
+"""
+
+_STATE_MERGE_QUERY = """\
+MERGE `{project}.{dataset}.{table}` T
+USING (
+  SELECT
+    @processor_name AS processor_name,
+    @checkpoint_timestamp AS checkpoint_timestamp,
+    @updated_at AS updated_at
+) S
+ON T.processor_name = S.processor_name
+WHEN MATCHED THEN
+  UPDATE SET
+    checkpoint_timestamp = S.checkpoint_timestamp,
+    updated_at = S.updated_at
+WHEN NOT MATCHED THEN
+  INSERT (
+    processor_name,
+    checkpoint_timestamp,
+    updated_at
+  )
+  VALUES (
+    S.processor_name,
+    S.checkpoint_timestamp,
+    S.updated_at
+  )
+"""
+
+_RUNS_INSERT_QUERY = """\
+INSERT INTO `{project}.{dataset}.{table}` (
+  processor_name,
+  run_started_at,
+  run_finished_at,
+  scan_start,
+  scan_end,
+  trigger_rows_found,
+  processed_rows,
+  duplicate_rows,
+  ignored_rows,
+  status,
+  error_message
+)
+VALUES (
+  @processor_name,
+  @run_started_at,
+  @run_finished_at,
+  @scan_start,
+  @scan_end,
+  @trigger_rows_found,
+  @processed_rows,
+  @duplicate_rows,
+  @ignored_rows,
+  @status,
+  @error_message
+)
+"""
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+  """Deployment configuration resolved from env vars."""
+
+  source_project: str
+  source_dataset: str
+  source_table: str
+  result_project: str
+  result_dataset: str
+  result_table: str
+  state_project: str
+  state_dataset: str
+  state_table: str
+  runs_project: str
+  runs_dataset: str
+  runs_table: str
+  processor_name: str
+  overlap: timedelta
+  initial_lookback: timedelta
+
+
+@dataclass
+class RunStats:
+  """Counters for one scheduled worker run."""
+
+  trigger_rows_found: int = 0
+  processed_rows: int = 0
+  duplicate_rows: int = 0
+  ignored_rows: int = 0
+
+
+def handle_scheduled_run(
+    body: dict[str, Any] | None = None,
+    *,
+    now: datetime | None = None,
+) -> tuple[dict[str, Any], int]:
+  """Process one Cloud Scheduler invocation."""
+  del body  # Reserved for future scheduler metadata.
+
+  run_started_at = now or datetime.now(timezone.utc)
+  client = None
+  config = None
+  scan_start = None
+  stats = RunStats()
+
+  try:
+    client = build_client_from_context({})
+    config = load_runtime_config(client)
+    checkpoint_timestamp = load_checkpoint(client, config)
+    scan_start = compute_scan_start(
+        run_started_at=run_started_at,
+        checkpoint_timestamp=checkpoint_timestamp,
+        overlap=config.overlap,
+        initial_lookback=config.initial_lookback,
+    )
+    evaluator = build_streaming_observability_evaluator()
+
+    for trigger in iter_triggers(client, config, scan_start, run_started_at):
+      stats.trigger_rows_found += 1
+      if not trigger.session_id:
+        logger.warning("Ignoring trigger row without session_id")
+        stats.ignored_rows += 1
+        continue
+
+      report = client.evaluate(
+          evaluator=evaluator,
+          filters=TraceFilter.from_cli_args(
+              session_id=trigger.session_id,
+              limit=1,
+          ),
+      )
+      if report.total_sessions == 0:
+        raise RuntimeError(
+            f"No evaluation rows returned for session_id={trigger.session_id}"
+        )
+
+      result_row = serialize_streaming_result_row(trigger, report)
+      inserted = persist_result_row(client, config, result_row)
+      if inserted:
+        stats.processed_rows += 1
+      else:
+        stats.duplicate_rows += 1
+
+    update_checkpoint(client, config, run_started_at)
+    write_run_history(
+        client=client,
+        config=config,
+        run_started_at=run_started_at,
+        run_finished_at=datetime.now(timezone.utc),
+        scan_start=scan_start,
+        scan_end=run_started_at,
+        stats=stats,
+        status="success",
+        error_message=None,
+    )
+  except Exception as exc:  # pragma: no cover - exercised in tests
+    logger.exception("Scheduled streaming evaluation run failed")
+    if client is not None and config is not None:
+      try:
+        write_run_history(
+            client=client,
+            config=config,
+            run_started_at=run_started_at,
+            run_finished_at=datetime.now(timezone.utc),
+            scan_start=scan_start or run_started_at,
+            scan_end=run_started_at,
+            stats=stats,
+            status="failed",
+            error_message=str(exc),
+        )
+      except Exception:  # pragma: no cover - defensive
+        logger.exception("Failed to persist streaming run history")
+    return {"status": "retry", "reason": str(exc)}, 500
+
+  return {
+      "status": "processed",
+      "processor_name": config.processor_name,
+      "scan_start": scan_start.isoformat(),
+      "scan_end": run_started_at.isoformat(),
+      "trigger_rows_found": stats.trigger_rows_found,
+      "processed_rows": stats.processed_rows,
+      "duplicate_rows": stats.duplicate_rows,
+      "ignored_rows": stats.ignored_rows,
+  }, 200
+
+
+def load_runtime_config(client) -> RuntimeConfig:
+  """Resolve worker configuration from deployment env vars."""
+  source_project = client.project_id
+  source_dataset = client.dataset_id
+  source_table = client.table_id
+
+  result_project = os.environ.get("BQ_AGENT_RESULT_PROJECT", source_project)
+  result_dataset = os.environ.get("BQ_AGENT_RESULT_DATASET", source_dataset)
+  result_table = os.environ.get("BQ_AGENT_RESULT_TABLE", STREAMING_RESULTS_TABLE)
+
+  state_project = os.environ.get("BQ_AGENT_STATE_PROJECT", result_project)
+  state_dataset = os.environ.get("BQ_AGENT_STATE_DATASET", result_dataset)
+  state_table = os.environ.get("BQ_AGENT_STATE_TABLE", STREAMING_STATE_TABLE)
+
+  runs_project = os.environ.get("BQ_AGENT_RUNS_PROJECT", result_project)
+  runs_dataset = os.environ.get("BQ_AGENT_RUNS_DATASET", result_dataset)
+  runs_table = os.environ.get("BQ_AGENT_RUNS_TABLE", STREAMING_RUNS_TABLE)
+
+  overlap_minutes = _env_int(
+      "BQ_AGENT_OVERLAP_MINUTES",
+      DEFAULT_OVERLAP_MINUTES,
+  )
+  initial_lookback_minutes = _env_int(
+      "BQ_AGENT_INITIAL_LOOKBACK_MINUTES",
+      DEFAULT_INITIAL_LOOKBACK_MINUTES,
+  )
+
+  return RuntimeConfig(
+      source_project=source_project,
+      source_dataset=source_dataset,
+      source_table=source_table,
+      result_project=result_project,
+      result_dataset=result_dataset,
+      result_table=result_table,
+      state_project=state_project,
+      state_dataset=state_dataset,
+      state_table=state_table,
+      runs_project=runs_project,
+      runs_dataset=runs_dataset,
+      runs_table=runs_table,
+      processor_name=os.environ.get(
+          "BQ_AGENT_PROCESSOR_NAME",
+          STREAMING_PROCESSOR_NAME,
+      ),
+      overlap=timedelta(minutes=overlap_minutes),
+      initial_lookback=timedelta(minutes=initial_lookback_minutes),
+  )
+
+
+def iter_triggers(client, config: RuntimeConfig, scan_start: datetime, scan_end: datetime):
+  """Yield normalized triggers from the overlap scan query."""
+  query = _TRIGGER_SCAN_QUERY.format(
+      project=config.source_project,
+      dataset=config.source_dataset,
+      table=config.source_table,
+  )
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter("scan_start", "TIMESTAMP", scan_start),
+          bigquery.ScalarQueryParameter("scan_end", "TIMESTAMP", scan_end),
+      ]
+  )
+
+  rows = client.bq_client.query(query, job_config=job_config).result()
+  for row in rows:
+    row_dict = _row_to_dict(row)
+    try:
+      yield parse_trigger_row(row_dict)
+    except ValueError as exc:
+      logger.warning("Ignoring malformed trigger row: %s", exc)
+      yield _IgnoredTrigger(row_dict, str(exc))
+
+
+def load_checkpoint(client, config: RuntimeConfig) -> datetime | None:
+  """Load the last successful run checkpoint timestamp."""
+  query = _LOAD_STATE_QUERY.format(
+      project=config.state_project,
+      dataset=config.state_dataset,
+      table=config.state_table,
+  )
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter(
+              "processor_name",
+              "STRING",
+              config.processor_name,
+          )
+      ]
+  )
+  rows = list(client.bq_client.query(query, job_config=job_config).result())
+  if not rows:
+    return None
+  return _row_to_dict(rows[0]).get("checkpoint_timestamp")
+
+
+def persist_result_row(
+    client,
+    config: RuntimeConfig,
+    row: dict[str, Any],
+) -> bool:
+  """Persist one result row idempotently via BigQuery MERGE."""
+  query = _RESULTS_MERGE_QUERY.format(
+      project=config.result_project,
+      dataset=config.result_dataset,
+      table=config.result_table,
+  )
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter("dedupe_key", "STRING", row["dedupe_key"]),
+          bigquery.ScalarQueryParameter("session_id", "STRING", row["session_id"]),
+          bigquery.ScalarQueryParameter("trace_id", "STRING", row["trace_id"]),
+          bigquery.ScalarQueryParameter("span_id", "STRING", row["span_id"]),
+          bigquery.ScalarQueryParameter(
+              "trigger_kind",
+              "STRING",
+              row["trigger_kind"],
+          ),
+          bigquery.ScalarQueryParameter(
+              "trigger_event_type",
+              "STRING",
+              row["trigger_event_type"],
+          ),
+          bigquery.ScalarQueryParameter(
+              "trigger_timestamp",
+              "TIMESTAMP",
+              row["trigger_timestamp"],
+          ),
+          bigquery.ScalarQueryParameter("is_final", "BOOL", row["is_final"]),
+          bigquery.ScalarQueryParameter(
+              "evaluator_profile",
+              "STRING",
+              row["evaluator_profile"],
+          ),
+          bigquery.ScalarQueryParameter("passed", "BOOL", row["passed"]),
+          bigquery.ScalarQueryParameter(
+              "aggregate_scores_json",
+              "STRING",
+              row["aggregate_scores_json"],
+          ),
+          bigquery.ScalarQueryParameter(
+              "details_json",
+              "STRING",
+              row["details_json"],
+          ),
+          bigquery.ScalarQueryParameter("report_json", "STRING", row["report_json"]),
+          bigquery.ScalarQueryParameter(
+              "processed_at",
+              "TIMESTAMP",
+              row["processed_at"],
+          ),
+      ]
+  )
+
+  job = client.bq_client.query(query, job_config=job_config)
+  job.result()
+  return bool(getattr(job, "num_dml_affected_rows", 0))
+
+
+def update_checkpoint(
+    client,
+    config: RuntimeConfig,
+    checkpoint_timestamp: datetime,
+) -> None:
+  """Advance the hidden processor checkpoint after a successful run."""
+  query = _STATE_MERGE_QUERY.format(
+      project=config.state_project,
+      dataset=config.state_dataset,
+      table=config.state_table,
+  )
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter(
+              "processor_name",
+              "STRING",
+              config.processor_name,
+          ),
+          bigquery.ScalarQueryParameter(
+              "checkpoint_timestamp",
+              "TIMESTAMP",
+              checkpoint_timestamp,
+          ),
+          bigquery.ScalarQueryParameter(
+              "updated_at",
+              "TIMESTAMP",
+              datetime.now(timezone.utc),
+          ),
+      ]
+  )
+  client.bq_client.query(query, job_config=job_config).result()
+
+
+def write_run_history(
+    client,
+    config: RuntimeConfig,
+    run_started_at: datetime,
+    run_finished_at: datetime,
+    scan_start: datetime,
+    scan_end: datetime,
+    stats: RunStats,
+    status: str,
+    error_message: str | None,
+) -> None:
+  """Write hidden run metadata for debugging and recovery analysis."""
+  query = _RUNS_INSERT_QUERY.format(
+      project=config.runs_project,
+      dataset=config.runs_dataset,
+      table=config.runs_table,
+  )
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter(
+              "processor_name",
+              "STRING",
+              config.processor_name,
+          ),
+          bigquery.ScalarQueryParameter(
+              "run_started_at",
+              "TIMESTAMP",
+              run_started_at,
+          ),
+          bigquery.ScalarQueryParameter(
+              "run_finished_at",
+              "TIMESTAMP",
+              run_finished_at,
+          ),
+          bigquery.ScalarQueryParameter("scan_start", "TIMESTAMP", scan_start),
+          bigquery.ScalarQueryParameter("scan_end", "TIMESTAMP", scan_end),
+          bigquery.ScalarQueryParameter(
+              "trigger_rows_found",
+              "INT64",
+              stats.trigger_rows_found,
+          ),
+          bigquery.ScalarQueryParameter(
+              "processed_rows",
+              "INT64",
+              stats.processed_rows,
+          ),
+          bigquery.ScalarQueryParameter(
+              "duplicate_rows",
+              "INT64",
+              stats.duplicate_rows,
+          ),
+          bigquery.ScalarQueryParameter("ignored_rows", "INT64", stats.ignored_rows),
+          bigquery.ScalarQueryParameter("status", "STRING", status),
+          bigquery.ScalarQueryParameter("error_message", "STRING", error_message),
+      ]
+  )
+  client.bq_client.query(query, job_config=job_config).result()
+
+
+class _IgnoredTrigger:
+  """Marker object used to keep per-row scan counts accurate."""
+
+  def __init__(self, row: dict[str, Any], reason: str):
+    self.row = row
+    self.reason = reason
+    self.session_id = ""
+
+
+def _row_to_dict(row: Any) -> dict[str, Any]:
+  """Convert BigQuery rows and dict-like values to plain dicts."""
+  if isinstance(row, dict):
+    return row
+  if hasattr(row, "items"):
+    return dict(row.items())
+  raise TypeError(f"Unsupported row type: {type(row)!r}")
+
+
+def _env_int(name: str, default: int) -> int:
+  """Read an integer env var with a strict fallback."""
+  raw = os.environ.get(name)
+  if raw is None:
+    return default
+  return int(raw)

--- a/deploy/streaming_evaluation/worker.py
+++ b/deploy/streaming_evaluation/worker.py
@@ -68,8 +68,10 @@ WHERE timestamp >= @scan_start
   AND (
     event_type = 'AGENT_COMPLETED'
     OR event_type = 'TOOL_ERROR'
-    OR status = 'ERROR'
-    OR error_message IS NOT NULL
+    OR (
+      status = 'ERROR'
+      AND error_message IS NOT NULL
+    )
   )
 ORDER BY trigger_timestamp ASC
 """
@@ -268,9 +270,12 @@ def handle_scheduled_run(
           ),
       )
       if report.total_sessions == 0:
-        raise RuntimeError(
-            f"No evaluation rows returned for session_id={trigger.session_id}"
+        logger.warning(
+            "No events found for session_id=%s; skipping trigger",
+            trigger.session_id,
         )
+        stats.ignored_rows += 1
+        continue
 
       result_row = serialize_streaming_result_row(trigger, report)
       inserted = persist_result_row(client, config, result_row)

--- a/src/bigquery_agent_analytics/_deploy_runtime.py
+++ b/src/bigquery_agent_analytics/_deploy_runtime.py
@@ -40,7 +40,7 @@ def resolve_client_options(
   )
   location = udc.get(
       "location",
-      os.environ.get("BQ_AGENT_LOCATION", "us-central1"),
+      os.environ.get("BQ_AGENT_LOCATION"),
   )
   endpoint = udc.get("endpoint") or os.environ.get("BQ_AGENT_ENDPOINT")
   connection_id = udc.get("connection_id") or os.environ.get(

--- a/src/bigquery_agent_analytics/_deploy_runtime.py
+++ b/src/bigquery_agent_analytics/_deploy_runtime.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared deployment runtime helpers.
+
+This module keeps deployment-specific bootstrap logic in one place so
+the BigQuery Remote Function path and the streaming evaluation worker
+use the same environment conventions when constructing an SDK client.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from bigquery_agent_analytics import Client
+
+
+def resolve_client_options(
+    user_defined_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+  """Resolve ``Client`` constructor kwargs from request context + env vars."""
+  udc = user_defined_context or {}
+  project_id = udc.get("project_id", os.environ.get("BQ_AGENT_PROJECT"))
+  dataset_id = udc.get("dataset_id", os.environ.get("BQ_AGENT_DATASET"))
+  table_id = udc.get(
+      "table_id",
+      os.environ.get("BQ_AGENT_TABLE", "agent_events"),
+  )
+  location = udc.get(
+      "location",
+      os.environ.get("BQ_AGENT_LOCATION", "us-central1"),
+  )
+  endpoint = udc.get("endpoint") or os.environ.get("BQ_AGENT_ENDPOINT")
+  connection_id = udc.get("connection_id") or os.environ.get(
+      "BQ_AGENT_CONNECTION_ID"
+  )
+
+  if not project_id or not dataset_id:
+    raise ValueError("project_id and dataset_id required")
+
+  return {
+      "project_id": project_id,
+      "dataset_id": dataset_id,
+      "table_id": table_id,
+      "location": location,
+      "verify_schema": False,
+      "endpoint": endpoint,
+      "connection_id": connection_id,
+  }
+
+
+def build_client_from_context(
+    user_defined_context: dict[str, Any] | None = None,
+) -> Client:
+  """Build a ``Client`` from request context + deployment env vars."""
+  return Client(**resolve_client_options(user_defined_context))

--- a/src/bigquery_agent_analytics/_streaming_evaluation.py
+++ b/src/bigquery_agent_analytics/_streaming_evaluation.py
@@ -1,0 +1,289 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for the scheduled streaming evaluation deployment surface."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+import hashlib
+import json
+from typing import Any
+
+from bigquery_agent_analytics import CodeEvaluator
+from bigquery_agent_analytics import EvaluationReport
+from bigquery_agent_analytics import serialize
+from bigquery_agent_analytics import udf_kernels
+
+STREAMING_EVALUATOR_PROFILE = "streaming_observability_v1"
+STREAMING_PROCESSOR_NAME = STREAMING_EVALUATOR_PROFILE
+STREAMING_RESULTS_TABLE = "streaming_evaluation_results"
+STREAMING_STATE_TABLE = "_streaming_eval_state"
+STREAMING_RUNS_TABLE = "_streaming_eval_runs"
+
+DEFAULT_POLL_INTERVAL_MINUTES = 5
+DEFAULT_OVERLAP_MINUTES = 15
+DEFAULT_INITIAL_LOOKBACK_MINUTES = 30
+
+TRIGGER_KIND_SESSION_TERMINAL = "session_terminal"
+TRIGGER_KIND_ERROR_EVENT = "error_event"
+_VALID_TRIGGER_KINDS = {
+    TRIGGER_KIND_SESSION_TERMINAL,
+    TRIGGER_KIND_ERROR_EVENT,
+}
+
+_LATENCY_THRESHOLD_MS = 5000.0
+_MAX_ERROR_RATE = 0.1
+_MAX_TURNS = 10
+
+
+@dataclass(frozen=True)
+class StreamingTrigger:
+  """Normalized trigger row from the scheduled overlap scan."""
+
+  session_id: str
+  trace_id: str | None
+  span_id: str | None
+  event_type: str
+  trigger_kind: str
+  trigger_timestamp: datetime
+  dedupe_key: str
+
+  @property
+  def is_final(self) -> bool:
+    return self.trigger_kind == TRIGGER_KIND_SESSION_TERMINAL
+
+
+def build_streaming_observability_evaluator() -> CodeEvaluator:
+  """Build the fixed launch evaluator profile for streaming observability."""
+
+  def _score_latency(session_summary: dict[str, Any]) -> float:
+    return udf_kernels.score_latency(
+        session_summary.get("avg_latency_ms", 0),
+        _LATENCY_THRESHOLD_MS,
+    )
+
+  def _score_error_rate(session_summary: dict[str, Any]) -> float:
+    return udf_kernels.score_error_rate(
+        session_summary.get("tool_calls", 0),
+        session_summary.get("tool_errors", 0),
+        _MAX_ERROR_RATE,
+    )
+
+  def _score_turn_count(session_summary: dict[str, Any]) -> float:
+    return udf_kernels.score_turn_count(
+        session_summary.get("turn_count", 0),
+        _MAX_TURNS,
+    )
+
+  evaluator = CodeEvaluator(name=STREAMING_EVALUATOR_PROFILE)
+  evaluator.add_metric("latency", _score_latency, threshold=0.5)
+  evaluator.add_metric("error_rate", _score_error_rate, threshold=0.5)
+  evaluator.add_metric("turn_count", _score_turn_count, threshold=0.5)
+  return evaluator
+
+
+def classify_trigger_kind(
+    event_type: str | None,
+    status: str | None = None,
+    error_message: str | None = None,
+) -> str | None:
+  """Classify an event row into a launch trigger kind."""
+  if event_type == "AGENT_COMPLETED":
+    return TRIGGER_KIND_SESSION_TERMINAL
+  if (
+      event_type == "TOOL_ERROR"
+      or status == "ERROR"
+      or error_message is not None
+  ):
+    return TRIGGER_KIND_ERROR_EVENT
+  return None
+
+
+def is_launch_trigger_row(
+    event_type: str | None,
+    status: str | None = None,
+    error_message: str | None = None,
+) -> bool:
+  """Return ``True`` when a row qualifies for launch trigger handling."""
+  return classify_trigger_kind(event_type, status, error_message) is not None
+
+
+def build_trigger_dedupe_key(
+    session_id: str,
+    trace_id: str | None,
+    span_id: str | None,
+    event_type: str,
+    trigger_timestamp: datetime | str,
+) -> str:
+  """Build a stable idempotency key for a trigger row."""
+  timestamp = _coerce_timestamp(trigger_timestamp)
+  timestamp_micros = int(timestamp.timestamp() * 1_000_000)
+  raw = "|".join(
+      [
+          session_id or "",
+          trace_id or "",
+          span_id or "",
+          event_type or "",
+          str(timestamp_micros),
+      ]
+  )
+  return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def parse_trigger_payload(payload: dict[str, Any]) -> StreamingTrigger:
+  """Parse a JSON payload into a validated ``StreamingTrigger``."""
+  missing = [
+      field
+      for field in (
+          "session_id",
+          "event_type",
+          "trigger_kind",
+          "trigger_timestamp",
+      )
+      if not payload.get(field)
+  ]
+  if missing:
+    raise ValueError(f"Missing required trigger fields: {', '.join(missing)}")
+
+  trigger_kind = payload["trigger_kind"]
+  if trigger_kind not in _VALID_TRIGGER_KINDS:
+    raise ValueError(f"Unsupported trigger_kind: {trigger_kind}")
+
+  trigger_timestamp = _coerce_timestamp(payload["trigger_timestamp"])
+  dedupe_key = payload.get("dedupe_key") or build_trigger_dedupe_key(
+      session_id=payload["session_id"],
+      trace_id=payload.get("trace_id"),
+      span_id=payload.get("span_id"),
+      event_type=payload["event_type"],
+      trigger_timestamp=trigger_timestamp,
+  )
+
+  return StreamingTrigger(
+      session_id=payload["session_id"],
+      trace_id=payload.get("trace_id"),
+      span_id=payload.get("span_id"),
+      event_type=payload["event_type"],
+      trigger_kind=trigger_kind,
+      trigger_timestamp=trigger_timestamp,
+      dedupe_key=dedupe_key,
+  )
+
+
+def parse_trigger_row(row: Mapping[str, Any]) -> StreamingTrigger:
+  """Parse a BigQuery row from the overlap scan into a ``StreamingTrigger``."""
+  payload = dict(row)
+  payload["trigger_timestamp"] = payload.get(
+      "trigger_timestamp"
+  ) or payload.get("timestamp")
+  payload["trigger_kind"] = payload.get(
+      "trigger_kind"
+  ) or classify_trigger_kind(
+      event_type=payload.get("event_type"),
+      status=payload.get("status"),
+      error_message=payload.get("error_message"),
+  )
+  return parse_trigger_payload(payload)
+
+
+def serialize_streaming_result_row(
+    trigger: StreamingTrigger,
+    report: EvaluationReport,
+    processed_at: datetime | None = None,
+) -> dict[str, Any]:
+  """Serialize one trigger execution to a fixed BigQuery row shape."""
+  processed = processed_at or datetime.now(timezone.utc)
+  session_score = report.session_scores[0] if report.session_scores else None
+  aggregate_scores = (
+      session_score.scores if session_score else report.aggregate_scores
+  )
+  details: dict[str, Any] = {}
+  if report.details:
+    details["report"] = report.details
+  if session_score and session_score.details:
+    details["session"] = session_score.details
+  if session_score and session_score.llm_feedback:
+    details["llm_feedback"] = session_score.llm_feedback
+
+  passed = False
+  if session_score is not None:
+    passed = session_score.passed
+  elif report.total_sessions > 0:
+    passed = report.failed_sessions == 0
+
+  return {
+      "dedupe_key": trigger.dedupe_key,
+      "session_id": trigger.session_id,
+      "trace_id": trigger.trace_id,
+      "span_id": trigger.span_id,
+      "trigger_kind": trigger.trigger_kind,
+      "trigger_event_type": trigger.event_type,
+      "trigger_timestamp": trigger.trigger_timestamp,
+      "is_final": trigger.is_final,
+      "evaluator_profile": STREAMING_EVALUATOR_PROFILE,
+      "passed": passed,
+      "aggregate_scores_json": json.dumps(aggregate_scores, sort_keys=True),
+      "details_json": json.dumps(details, sort_keys=True),
+      "report_json": json.dumps(serialize(report), sort_keys=True),
+      "processed_at": processed,
+  }
+
+
+def compute_scan_start(
+    run_started_at: datetime | str,
+    checkpoint_timestamp: datetime | str | None = None,
+    overlap: timedelta | None = None,
+    initial_lookback: timedelta | None = None,
+) -> datetime:
+  """Compute the lower bound for the next overlap scan."""
+  run_started = _coerce_timestamp(run_started_at)
+  overlap_window = overlap or timedelta(minutes=DEFAULT_OVERLAP_MINUTES)
+  bootstrap_window = initial_lookback or timedelta(
+      minutes=DEFAULT_INITIAL_LOOKBACK_MINUTES
+  )
+
+  if checkpoint_timestamp is None:
+    return run_started - bootstrap_window
+
+  checkpoint = _coerce_timestamp(checkpoint_timestamp)
+  if checkpoint > run_started:
+    checkpoint = run_started
+  return checkpoint - overlap_window
+
+
+def _coerce_timestamp(value: datetime | str) -> datetime:
+  """Parse timestamps into UTC datetimes."""
+  if isinstance(value, datetime):
+    if value.tzinfo is None:
+      return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+  normalized = value.strip()
+  if normalized.endswith(" UTC"):
+    normalized = normalized.removesuffix(" UTC") + "+00:00"
+  if normalized.endswith("Z"):
+    normalized = normalized[:-1] + "+00:00"
+
+  try:
+    parsed = datetime.fromisoformat(normalized)
+  except ValueError as exc:
+    raise ValueError(f"Invalid trigger_timestamp: {value}") from exc
+
+  if parsed.tzinfo is None:
+    parsed = parsed.replace(tzinfo=timezone.utc)
+  return parsed.astimezone(timezone.utc)

--- a/src/bigquery_agent_analytics/_streaming_evaluation.py
+++ b/src/bigquery_agent_analytics/_streaming_evaluation.py
@@ -106,11 +106,9 @@ def classify_trigger_kind(
   """Classify an event row into a launch trigger kind."""
   if event_type == "AGENT_COMPLETED":
     return TRIGGER_KIND_SESSION_TERMINAL
-  if (
-      event_type == "TOOL_ERROR"
-      or status == "ERROR"
-      or error_message is not None
-  ):
+  if event_type == "TOOL_ERROR":
+    return TRIGGER_KIND_ERROR_EVENT
+  if status == "ERROR" and error_message is not None:
     return TRIGGER_KIND_ERROR_EVENT
   return None
 

--- a/tests/test_streaming_evaluation.py
+++ b/tests/test_streaming_evaluation.py
@@ -410,6 +410,44 @@ class TestWorker:
     assert response["ignored_rows"] == 1
     client.evaluate.assert_not_called()
 
+  def test_malformed_row_is_counted_once(
+      self,
+      streaming_worker,
+      monkeypatch,
+      caplog,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+            }
+        ]
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 200
+    assert response["ignored_rows"] == 1
+    assert caplog.messages == [
+        "Ignoring malformed trigger row: Missing required trigger fields: event_type, trigger_kind"
+    ]
+    client.evaluate.assert_not_called()
+
   def test_bigquery_or_evaluation_failure_retries(
       self,
       streaming_worker,
@@ -445,6 +483,47 @@ class TestWorker:
 
     assert status == 500
     assert response["status"] == "retry"
+
+  def test_checkpoint_does_not_advance_if_success_history_write_fails(
+      self,
+      streaming_worker,
+      monkeypatch,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "session_terminal",
+            }
+        ],
+        error_on="INSERT INTO",
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.return_value = _report()
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 500
+    assert response["status"] == "retry"
+    state_queries = [
+        query for query in fake_bq.queries if "_streaming_eval_state" in query
+    ]
+    assert len(state_queries) == 1
 
   def test_same_session_can_emit_error_and_terminal_rows(
       self,
@@ -529,14 +608,22 @@ class TestDeployAssets:
   def test_setup_assets_point_to_scheduler_and_state_tables(self):
     setup_sh = (_ROOT / "deploy/streaming_evaluation/setup.sh").read_text()
     readme = (_ROOT / "deploy/streaming_evaluation/README.md").read_text()
+    requirements = (
+        _ROOT / "deploy/streaming_evaluation/requirements.txt"
+    ).read_text()
 
     assert ".streaming_evaluation_state.json" in setup_sh
     assert "streaming_evaluation_results" in setup_sh
     assert "_streaming_eval_state" in setup_sh
     assert "_streaming_eval_runs" in setup_sh
+    assert 'PROJECT and DATASET are required for "up"' in setup_sh
+    assert 'cp "$SCRIPT_DIR/requirements.txt" "$staging/"' in setup_sh
+    assert "wait_for_service_account" in setup_sh
     assert "scheduler jobs create http" in setup_sh
     assert "cloudscheduler.googleapis.com" in setup_sh
+    assert "roles/iam.serviceAccountOpenIdTokenCreator" in setup_sh
     assert "--timeout 300" in setup_sh
     assert "Cloud Scheduler" in readme
     assert "No special BigQuery reservation is required" in readme
     assert "enable the required Cloud Run" in readme
+    assert "pyyaml>=6.0" in requirements

--- a/tests/test_streaming_evaluation.py
+++ b/tests/test_streaming_evaluation.py
@@ -22,6 +22,7 @@ from datetime import timezone
 import importlib.util
 import json
 from pathlib import Path
+import subprocess
 import sys
 from unittest.mock import MagicMock
 
@@ -117,7 +118,7 @@ class _FakeSelectJob:
 
 class _FakeDmlJob:
 
-  def __init__(self, affected_rows: int = 1):
+  def __init__(self, affected_rows: int | None = 1):
     self.num_dml_affected_rows = affected_rows
 
   def result(self):
@@ -523,6 +524,7 @@ class TestWorker:
 
     assert status == 500
     assert response["status"] == "retry"
+    assert response["reason"] == "internal error"
 
   def test_zero_session_report_is_skipped_not_retried(
       self,
@@ -583,7 +585,7 @@ class TestWorker:
                 "trigger_kind": "session_terminal",
             }
         ],
-        error_on="INSERT INTO",
+        error_on="_streaming_eval_runs",
     )
     client = MagicMock()
     client.project_id = "proj"
@@ -605,6 +607,95 @@ class TestWorker:
         query for query in fake_bq.queries if "_streaming_eval_state" in query
     ]
     assert len(state_queries) == 1
+
+  def test_checkpoint_failure_rewrites_success_run_history_to_failed(
+      self,
+      streaming_worker,
+      monkeypatch,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "session_terminal",
+            }
+        ],
+        error_on="checkpoint_timestamp = S.checkpoint_timestamp",
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.return_value = _report()
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 500
+    assert response["reason"] == "internal error"
+    runs_writes = []
+    for query, job_config in zip(fake_bq.queries, fake_bq.job_configs):
+      if "_streaming_eval_runs" in query:
+        runs_writes.append(
+            {param.name: param.value for param in job_config.query_parameters}
+        )
+
+    assert [write["status"] for write in runs_writes] == ["success", "failed"]
+    assert runs_writes[-1]["error_message"] == "transient failure"
+
+  def test_missing_dml_stats_are_treated_as_processed(
+      self,
+      streaming_worker,
+      monkeypatch,
+      caplog,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "session_terminal",
+            }
+        ],
+        merge_affected_rows=[None],
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.return_value = _report()
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 200
+    assert response["processed_rows"] == 1
+    assert response["duplicate_rows"] == 0
+    assert any(
+        "BigQuery DML stats were unavailable" in message
+        for message in caplog.messages
+    )
 
   def test_same_session_can_emit_error_and_terminal_rows(
       self,
@@ -660,6 +751,25 @@ class TestWorker:
     assert [row["trigger_kind"] for row in persisted] == [
         "error_event",
         "session_terminal",
+    ]
+
+  def test_invalid_overlap_env_uses_default(
+      self,
+      streaming_worker,
+      monkeypatch,
+      caplog,
+  ):
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    monkeypatch.setenv("BQ_AGENT_OVERLAP_MINUTES", "fifteen")
+
+    config = streaming_worker.load_runtime_config(client)
+
+    assert config.overlap == timedelta(minutes=15)
+    assert caplog.messages == [
+        "Invalid integer value for BQ_AGENT_OVERLAP_MINUTES='fifteen'; using default 15"
     ]
 
 
@@ -727,9 +837,49 @@ class TestDeployAssets:
     assert "cloudscheduler.googleapis.com" in setup_sh
     assert "roles/iam.serviceAccountOpenIdTokenCreator" in setup_sh
     assert "--timeout 300" in setup_sh
+    assert "trap 'rm -rf \"$staging\"' RETURN" in setup_sh
     assert "Cloud Scheduler" in readme
     assert "No special BigQuery reservation is required" in readme
     assert "enable the required Cloud Run" in readme
     assert "BigQuery tables were preserved intentionally" in setup_sh
     assert "intentionally preserves the BigQuery tables" in readme
     assert "pyyaml>=6.0" in requirements
+    assert "google-adk" not in requirements
+    assert setup_sh.index(
+        'ensure_scheduler_job "$scheduler_sa_email" "$url"'
+    ) < (setup_sh.index('write_state "$bq_location" "$scheduler_sa_email"'))
+
+  def test_streaming_worker_import_does_not_require_google_adk(self):
+    script = f"""
+import builtins
+import importlib.util
+import pathlib
+import sys
+
+root = pathlib.Path({str(_ROOT)!r})
+orig_import = builtins.__import__
+
+def blocked(name, globals=None, locals=None, fromlist=(), level=0):
+  if name == "google.adk" or name.startswith("google.adk."):
+    raise ImportError("blocked google.adk")
+  return orig_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = blocked
+sys.path.insert(0, str(root / "src"))
+spec = importlib.util.spec_from_file_location(
+    "streaming_worker_no_adk",
+    root / "deploy/streaming_evaluation/worker.py",
+)
+module = importlib.util.module_from_spec(spec)
+sys.modules["streaming_worker_no_adk"] = module
+spec.loader.exec_module(module)
+print("ok")
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        cwd=_ROOT,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/tests/test_streaming_evaluation.py
+++ b/tests/test_streaming_evaluation.py
@@ -1,0 +1,542 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the scheduled streaming evaluation deployment path."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from bigquery_agent_analytics._deploy_runtime import resolve_client_options
+from bigquery_agent_analytics._streaming_evaluation import build_streaming_observability_evaluator
+from bigquery_agent_analytics._streaming_evaluation import build_trigger_dedupe_key
+from bigquery_agent_analytics._streaming_evaluation import classify_trigger_kind
+from bigquery_agent_analytics._streaming_evaluation import compute_scan_start
+from bigquery_agent_analytics._streaming_evaluation import parse_trigger_payload
+from bigquery_agent_analytics._streaming_evaluation import parse_trigger_row
+from bigquery_agent_analytics._streaming_evaluation import serialize_streaming_result_row
+from bigquery_agent_analytics._streaming_evaluation import STREAMING_EVALUATOR_PROFILE
+from bigquery_agent_analytics.evaluators import EvaluationReport
+from bigquery_agent_analytics.evaluators import SessionScore
+
+_ROOT = Path(__file__).resolve().parents[1]
+_NOW = datetime(2026, 3, 28, 18, 30, 0, tzinfo=timezone.utc)
+
+
+def _import_module(name: str, relative_path: str):
+  spec = importlib.util.spec_from_file_location(
+      name,
+      _ROOT / relative_path,
+  )
+  mod = importlib.util.module_from_spec(spec)
+  sys.modules[name] = mod
+  spec.loader.exec_module(mod)
+  return mod
+
+
+def _report() -> EvaluationReport:
+  return EvaluationReport(
+      dataset="test",
+      evaluator_name=STREAMING_EVALUATOR_PROFILE,
+      total_sessions=1,
+      passed_sessions=1,
+      failed_sessions=0,
+      aggregate_scores={
+          "latency": 0.9,
+          "error_rate": 1.0,
+          "turn_count": 0.8,
+      },
+      details={"source": "unit-test"},
+      created_at=_NOW,
+      session_scores=[
+          SessionScore(
+              session_id="sess-1",
+              scores={
+                  "latency": 0.9,
+                  "error_rate": 1.0,
+                  "turn_count": 0.8,
+              },
+              passed=True,
+              details={"checked": True},
+          )
+      ],
+  )
+
+
+class _FakeSelectJob:
+
+  def __init__(self, rows):
+    self._rows = rows
+
+  def result(self):
+    return self._rows
+
+
+class _FakeDmlJob:
+
+  def __init__(self, affected_rows: int = 1):
+    self.num_dml_affected_rows = affected_rows
+
+  def result(self):
+    return None
+
+
+class _FakeBigQueryClient:
+
+  def __init__(
+      self,
+      *,
+      checkpoint_rows=None,
+      trigger_rows=None,
+      merge_affected_rows=None,
+      error_on: str | None = None,
+  ):
+    self.checkpoint_rows = checkpoint_rows or []
+    self.trigger_rows = trigger_rows or []
+    self.merge_affected_rows = list(merge_affected_rows or [])
+    self.error_on = error_on
+    self.queries = []
+    self.job_configs = []
+
+  def query(self, query, job_config=None):
+    self.queries.append(query)
+    self.job_configs.append(job_config)
+    if self.error_on and self.error_on in query:
+      raise RuntimeError("transient failure")
+    compact = query.lstrip()
+    if compact.startswith("SELECT checkpoint_timestamp"):
+      return _FakeSelectJob(self.checkpoint_rows)
+    if compact.startswith("SELECT\n  session_id,"):
+      return _FakeSelectJob(self.trigger_rows)
+    if "streaming_evaluation_results" in query:
+      affected_rows = (
+          self.merge_affected_rows.pop(0) if self.merge_affected_rows else 1
+      )
+      return _FakeDmlJob(affected_rows)
+    if compact.startswith("MERGE") or compact.startswith("INSERT INTO"):
+      return _FakeDmlJob(1)
+    raise AssertionError(f"Unexpected query: {query}")
+
+
+@pytest.fixture(scope="module")
+def rf_dispatch():
+  return _import_module("rf_dispatch", "deploy/remote_function/dispatch.py")
+
+
+@pytest.fixture(scope="module")
+def streaming_worker():
+  return _import_module(
+      "streaming_worker",
+      "deploy/streaming_evaluation/worker.py",
+  )
+
+
+class TestSharedRuntime:
+
+  def test_resolve_client_options_from_env(self, monkeypatch):
+    monkeypatch.setenv("BQ_AGENT_PROJECT", "env-project")
+    monkeypatch.setenv("BQ_AGENT_DATASET", "env-dataset")
+    monkeypatch.setenv("BQ_AGENT_TABLE", "env-table")
+    monkeypatch.setenv("BQ_AGENT_LOCATION", "US")
+
+    options = resolve_client_options({})
+    assert options["project_id"] == "env-project"
+    assert options["dataset_id"] == "env-dataset"
+    assert options["table_id"] == "env-table"
+    assert options["location"] == "US"
+    assert options["verify_schema"] is False
+
+  def test_remote_and_streaming_import_same_resolver(
+      self,
+      rf_dispatch,
+      streaming_worker,
+  ):
+    assert rf_dispatch.resolve_client_options is resolve_client_options
+    assert streaming_worker.resolve_client_options is resolve_client_options
+
+
+class TestHelpers:
+
+  def test_streaming_profile_contains_fixed_metrics(self):
+    evaluator = build_streaming_observability_evaluator()
+    metric_names = [metric.name for metric in evaluator._metrics]
+
+    assert evaluator.name == STREAMING_EVALUATOR_PROFILE
+    assert metric_names == ["latency", "error_rate", "turn_count"]
+
+  def test_dedupe_key_is_stable(self):
+    first = build_trigger_dedupe_key(
+        session_id="sess-1",
+        trace_id="trace-1",
+        span_id="span-1",
+        event_type="AGENT_COMPLETED",
+        trigger_timestamp=_NOW,
+    )
+    second = build_trigger_dedupe_key(
+        session_id="sess-1",
+        trace_id="trace-1",
+        span_id="span-1",
+        event_type="AGENT_COMPLETED",
+        trigger_timestamp="2026-03-28T18:30:00Z",
+    )
+
+    assert first == second
+
+  def test_classify_trigger_kind_prefers_terminal_then_error(self):
+    assert classify_trigger_kind("AGENT_COMPLETED") == "session_terminal"
+    assert classify_trigger_kind("TOOL_ERROR") == "error_event"
+    assert classify_trigger_kind("AGENT_STEP", status="ERROR") == "error_event"
+    assert (
+        classify_trigger_kind("AGENT_STEP", error_message="boom")
+        == "error_event"
+    )
+    assert classify_trigger_kind("AGENT_STEP") is None
+
+  def test_parse_trigger_row_classifies_from_overlap_scan_fields(self):
+    trigger = parse_trigger_row(
+        {
+            "session_id": "sess-1",
+            "trace_id": "trace-1",
+            "span_id": "span-1",
+            "event_type": "TOOL_ERROR",
+            "status": "ERROR",
+            "error_message": "boom",
+            "trigger_timestamp": "2026-03-28T18:30:00Z",
+        }
+    )
+
+    assert trigger.trigger_kind == "error_event"
+    assert trigger.is_final is False
+
+  def test_compute_scan_start_uses_checkpoint_overlap(self):
+    scan_start = compute_scan_start(
+        run_started_at=_NOW,
+        checkpoint_timestamp=_NOW,
+        overlap=timedelta(minutes=15),
+        initial_lookback=timedelta(minutes=30),
+    )
+    assert scan_start == _NOW - timedelta(minutes=15)
+
+  def test_compute_scan_start_bootstraps_with_initial_lookback(self):
+    scan_start = compute_scan_start(
+        run_started_at=_NOW,
+        checkpoint_timestamp=None,
+        overlap=timedelta(minutes=15),
+        initial_lookback=timedelta(minutes=30),
+    )
+    assert scan_start == _NOW - timedelta(minutes=30)
+
+  def test_serialize_result_row_uses_session_scores(self):
+    trigger = parse_trigger_payload(
+        {
+            "session_id": "sess-1",
+            "trace_id": "trace-1",
+            "span_id": "span-1",
+            "event_type": "AGENT_COMPLETED",
+            "trigger_kind": "session_terminal",
+            "trigger_timestamp": "2026-03-28T18:30:00Z",
+        }
+    )
+
+    row = serialize_streaming_result_row(trigger, _report(), processed_at=_NOW)
+
+    assert row["session_id"] == "sess-1"
+    assert row["trigger_kind"] == "session_terminal"
+    assert row["is_final"] is True
+    assert row["evaluator_profile"] == STREAMING_EVALUATOR_PROFILE
+    assert row["passed"] is True
+    assert json.loads(row["aggregate_scores_json"]) == {
+        "error_rate": 1.0,
+        "latency": 0.9,
+        "turn_count": 0.8,
+    }
+    assert json.loads(row["details_json"]) == {
+        "report": {"source": "unit-test"},
+        "session": {"checked": True},
+    }
+
+
+class TestWorker:
+
+  def test_valid_run_processes_and_persists(
+      self,
+      streaming_worker,
+      monkeypatch,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "session_terminal",
+            }
+        ]
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.return_value = _report()
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 200
+    assert response["status"] == "processed"
+    assert response["processed_rows"] == 1
+    assert response["duplicate_rows"] == 0
+    assert response["ignored_rows"] == 0
+    client.evaluate.assert_called_once()
+
+    trigger_scan_config = fake_bq.job_configs[1]
+    scan_params = {
+        param.name: param.value
+        for param in trigger_scan_config.query_parameters
+    }
+    assert scan_params["scan_start"] == _NOW - timedelta(minutes=30)
+    assert scan_params["scan_end"] == _NOW
+
+    result_params = None
+    for query, job_config in zip(fake_bq.queries, fake_bq.job_configs):
+      if "streaming_evaluation_results" in query:
+        result_params = {
+            param.name: param.value for param in job_config.query_parameters
+        }
+        break
+
+    assert result_params is not None
+    assert result_params["session_id"] == "sess-1"
+    assert result_params["trigger_kind"] == "session_terminal"
+    assert result_params["is_final"] is True
+    assert result_params["evaluator_profile"] == STREAMING_EVALUATOR_PROFILE
+
+  def test_duplicate_trigger_returns_200(self, streaming_worker, monkeypatch):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "TOOL_ERROR",
+                "status": "ERROR",
+                "error_message": "boom",
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "error_event",
+            }
+        ],
+        merge_affected_rows=[0],
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.return_value = _report()
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 200
+    assert response["status"] == "processed"
+    assert response["processed_rows"] == 0
+    assert response["duplicate_rows"] == 1
+
+  def test_missing_session_id_is_ignored(
+      self,
+      streaming_worker,
+      monkeypatch,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "session_terminal",
+            }
+        ]
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 200
+    assert response["ignored_rows"] == 1
+    client.evaluate.assert_not_called()
+
+  def test_bigquery_or_evaluation_failure_retries(
+      self,
+      streaming_worker,
+      monkeypatch,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "session_terminal",
+            }
+        ]
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.side_effect = RuntimeError("transient failure")
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 500
+    assert response["status"] == "retry"
+
+  def test_same_session_can_emit_error_and_terminal_rows(
+      self,
+      streaming_worker,
+      monkeypatch,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-error",
+                "event_type": "TOOL_ERROR",
+                "status": "ERROR",
+                "error_message": "boom",
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "error_event",
+            },
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-final",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW + timedelta(minutes=1),
+                "trigger_kind": "session_terminal",
+            },
+        ]
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.return_value = _report()
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 200
+    assert response["processed_rows"] == 2
+    persisted = []
+    for query, job_config in zip(fake_bq.queries, fake_bq.job_configs):
+      if "streaming_evaluation_results" in query:
+        persisted.append(
+            {param.name: param.value for param in job_config.query_parameters}
+        )
+    assert [row["trigger_kind"] for row in persisted] == [
+        "error_event",
+        "session_terminal",
+    ]
+
+
+class TestDeployAssets:
+
+  def test_trigger_query_contains_exact_launch_filters(self):
+    sql = (_ROOT / "deploy/streaming_evaluation/trigger_query.sql").read_text()
+
+    assert "event_type = 'AGENT_COMPLETED'" in sql
+    assert "event_type = 'TOOL_ERROR'" in sql
+    assert "status = 'ERROR'" in sql
+    assert "error_message IS NOT NULL" in sql
+
+  def test_trigger_query_contains_expected_scan_fields(self):
+    sql = (_ROOT / "deploy/streaming_evaluation/trigger_query.sql").read_text()
+
+    for field in (
+        "session_id",
+        "trace_id",
+        "span_id",
+        "event_type",
+        "trigger_timestamp",
+        "trigger_kind",
+    ):
+      assert field in sql
+
+  def test_setup_assets_point_to_scheduler_and_state_tables(self):
+    setup_sh = (_ROOT / "deploy/streaming_evaluation/setup.sh").read_text()
+    readme = (_ROOT / "deploy/streaming_evaluation/README.md").read_text()
+
+    assert ".streaming_evaluation_state.json" in setup_sh
+    assert "streaming_evaluation_results" in setup_sh
+    assert "_streaming_eval_state" in setup_sh
+    assert "_streaming_eval_runs" in setup_sh
+    assert "scheduler jobs create http" in setup_sh
+    assert "cloudscheduler.googleapis.com" in setup_sh
+    assert "--timeout 300" in setup_sh
+    assert "Cloud Scheduler" in readme
+    assert "No special BigQuery reservation is required" in readme
+    assert "enable the required Cloud Run" in readme

--- a/tests/test_streaming_evaluation.py
+++ b/tests/test_streaming_evaluation.py
@@ -54,6 +54,15 @@ def _import_module(name: str, relative_path: str):
   return mod
 
 
+def _normalize_sql(sql_text: str) -> str:
+  lines = [
+      line.strip()
+      for line in sql_text.splitlines()
+      if line.strip() and not line.strip().startswith("--")
+  ]
+  return " ".join(lines).rstrip(";")
+
+
 def _report() -> EvaluationReport:
   return EvaluationReport(
       dataset="test",
@@ -80,6 +89,20 @@ def _report() -> EvaluationReport:
               details={"checked": True},
           )
       ],
+  )
+
+
+def _empty_report() -> EvaluationReport:
+  return EvaluationReport(
+      dataset="test",
+      evaluator_name=STREAMING_EVALUATOR_PROFILE,
+      total_sessions=0,
+      passed_sessions=0,
+      failed_sessions=0,
+      aggregate_scores={},
+      details={"source": "unit-test"},
+      created_at=_NOW,
+      session_scores=[],
   )
 
 
@@ -166,6 +189,18 @@ class TestSharedRuntime:
     assert options["location"] == "US"
     assert options["verify_schema"] is False
 
+  def test_resolve_client_options_leaves_location_unset_by_default(
+      self,
+      monkeypatch,
+  ):
+    monkeypatch.setenv("BQ_AGENT_PROJECT", "env-project")
+    monkeypatch.setenv("BQ_AGENT_DATASET", "env-dataset")
+    monkeypatch.delenv("BQ_AGENT_LOCATION", raising=False)
+
+    options = resolve_client_options({})
+
+    assert options["location"] is None
+
   def test_remote_and_streaming_import_same_resolver(
       self,
       rf_dispatch,
@@ -205,11 +240,16 @@ class TestHelpers:
   def test_classify_trigger_kind_prefers_terminal_then_error(self):
     assert classify_trigger_kind("AGENT_COMPLETED") == "session_terminal"
     assert classify_trigger_kind("TOOL_ERROR") == "error_event"
-    assert classify_trigger_kind("AGENT_STEP", status="ERROR") == "error_event"
     assert (
-        classify_trigger_kind("AGENT_STEP", error_message="boom")
+        classify_trigger_kind(
+            "AGENT_STEP",
+            status="ERROR",
+            error_message="boom",
+        )
         == "error_event"
     )
+    assert classify_trigger_kind("AGENT_STEP", status="ERROR") is None
+    assert classify_trigger_kind("AGENT_STEP", error_message="boom") is None
     assert classify_trigger_kind("AGENT_STEP") is None
 
   def test_parse_trigger_row_classifies_from_overlap_scan_fields(self):
@@ -484,6 +524,47 @@ class TestWorker:
     assert status == 500
     assert response["status"] == "retry"
 
+  def test_zero_session_report_is_skipped_not_retried(
+      self,
+      streaming_worker,
+      monkeypatch,
+      caplog,
+  ):
+    fake_bq = _FakeBigQueryClient(
+        trigger_rows=[
+            {
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "event_type": "AGENT_COMPLETED",
+                "status": "OK",
+                "error_message": None,
+                "trigger_timestamp": _NOW,
+                "trigger_kind": "session_terminal",
+            }
+        ]
+    )
+    client = MagicMock()
+    client.project_id = "proj"
+    client.dataset_id = "agent_trace"
+    client.table_id = "agent_events"
+    client.bq_client = fake_bq
+    client.evaluate.return_value = _empty_report()
+    monkeypatch.setattr(
+        streaming_worker,
+        "build_client_from_context",
+        MagicMock(return_value=client),
+    )
+
+    response, status = streaming_worker.handle_scheduled_run({}, now=_NOW)
+
+    assert status == 200
+    assert response["processed_rows"] == 0
+    assert response["ignored_rows"] == 1
+    assert caplog.messages[-1] == (
+        "No events found for session_id=sess-1; skipping trigger"
+    )
+
   def test_checkpoint_does_not_advance_if_success_history_write_fails(
       self,
       streaming_worker,
@@ -591,6 +672,29 @@ class TestDeployAssets:
     assert "event_type = 'TOOL_ERROR'" in sql
     assert "status = 'ERROR'" in sql
     assert "error_message IS NOT NULL" in sql
+    assert "OR status = 'ERROR'" not in sql
+
+  def test_trigger_query_matches_worker_scan_query(self, streaming_worker):
+    sql = (_ROOT / "deploy/streaming_evaluation/trigger_query.sql").read_text()
+    normalized_file = (
+        _normalize_sql(sql)
+        .replace(
+            "`PROJECT.DATASET.SOURCE_TABLE`",
+            "`{project}.{dataset}.{table}`",
+        )
+        .replace(
+            "SCAN_START",
+            "@scan_start",
+        )
+        .replace(
+            "SCAN_END",
+            "@scan_end",
+        )
+    )
+
+    assert normalized_file == _normalize_sql(
+        streaming_worker._TRIGGER_SCAN_QUERY
+    )
 
   def test_trigger_query_contains_expected_scan_fields(self):
     sql = (_ROOT / "deploy/streaming_evaluation/trigger_query.sql").read_text()
@@ -626,4 +730,6 @@ class TestDeployAssets:
     assert "Cloud Scheduler" in readme
     assert "No special BigQuery reservation is required" in readme
     assert "enable the required Cloud Run" in readme
+    assert "BigQuery tables were preserved intentionally" in setup_sh
+    assert "intentionally preserves the BigQuery tables" in readme
     assert "pyyaml>=6.0" in requirements


### PR DESCRIPTION
## Summary

Add a scheduler-based streaming evaluation path for real-time observability.

```mermaid
flowchart LR
  A["agent_events"] --> B["Cloud Scheduler (5 min)"]
  B --> C["Cloud Run worker"]
  C --> D["overlap scan + dedupe + checkpoint"]
  D --> E["SDK evaluation"]
  E --> F["streaming_evaluation_results"]
```

This adds a dedicated Cloud Run worker that scans recent `agent_events` rows, evaluates affected sessions with the SDK, and writes results back to BigQuery.

Closes #50.

## Why this design

We chose `Cloud Scheduler -> Cloud Run -> BigQuery overlap scan` as the default path because it is:

- cheaper than continuous queries
- simpler to deploy
- compatible with BigQuery as the current source of truth

## What’s included

- new deployment flow under `deploy/streaming_evaluation/`
- scheduled Cloud Run worker with overlap scan, dedupe, and hidden checkpoint state
- shared deploy runtime helpers reused by the remote-function path
- BigQuery result persistence and internal run tracking
- setup docs and README updates
- unit tests for trigger parsing, checkpointing, dedupe, and worker behavior
