### PR TITLE
fix: add location configurability to Dashboard V2 notebook

### DIFF
--- a/examples/dashboard_v2.ipynb
+++ b/examples/dashboard_v2.ipynb
@@ -6,10 +6,10 @@
    "id": "license",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:04:35.231905Z",
-     "iopub.status.busy": "2026-04-08T15:04:35.231743Z",
-     "iopub.status.idle": "2026-04-08T15:04:35.235445Z",
-     "shell.execute_reply": "2026-04-08T15:04:35.234760Z"
+     "iopub.execute_input": "2026-04-11T06:41:45.045707Z",
+     "iopub.status.busy": "2026-04-11T06:41:45.045553Z",
+     "iopub.status.idle": "2026-04-11T06:41:45.048984Z",
+     "shell.execute_reply": "2026-04-11T06:41:45.048431Z"
     }
    },
    "outputs": [],
@@ -98,10 +98,10 @@
    "id": "cell-0-deps",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:04:35.237607Z",
-     "iopub.status.busy": "2026-04-08T15:04:35.237502Z",
-     "iopub.status.idle": "2026-04-08T15:04:38.588179Z",
-     "shell.execute_reply": "2026-04-08T15:04:38.587629Z"
+     "iopub.execute_input": "2026-04-11T06:41:45.051022Z",
+     "iopub.status.busy": "2026-04-11T06:41:45.050916Z",
+     "iopub.status.idle": "2026-04-11T06:41:48.187666Z",
+     "shell.execute_reply": "2026-04-11T06:41:48.187125Z"
     }
    },
    "outputs": [
@@ -149,10 +149,10 @@
    "id": "cell-1-config",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:04:38.589965Z",
-     "iopub.status.busy": "2026-04-08T15:04:38.589792Z",
-     "iopub.status.idle": "2026-04-08T15:04:40.574664Z",
-     "shell.execute_reply": "2026-04-08T15:04:40.573508Z"
+     "iopub.execute_input": "2026-04-11T06:41:48.189567Z",
+     "iopub.status.busy": "2026-04-11T06:41:48.189394Z",
+     "iopub.status.idle": "2026-04-11T06:41:50.295558Z",
+     "shell.execute_reply": "2026-04-11T06:41:50.294475Z"
     }
    },
    "outputs": [
@@ -160,8 +160,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Session  : ChoKGHRlc3QtcHJvamVjdC0wNzI4LTQ2NzMyMxABGiQ1OWVhZDk3Yy02YmI0LTQzNjItYjI5ZC1lODE5YzY0YWEyN2M=\n",
+      "Session  : ChoKGHRlc3QtcHJvamVjdC0wNzI4LTQ2NzMyMxABGiRmNjNhOTk0Yy0yZGYxLTRjY2QtODk4Zi1lYjJiMzY0YTc2NDA=\n",
       "Project  : test-project-0728-467323\n",
+      "Location : (auto)\n",
       "Dataset  : agent_analytics\n",
       "Table    : agent_events\n",
       "Time     : last 720 hours\n",
@@ -175,6 +176,7 @@
     "DATASET_ID = os.environ.get(\"BQ_DATASET\", \"agent_analytics\")\n",
     "TABLE_ID   = os.environ.get(\"BQ_TABLE\", \"agent_events\")\n",
     "TABLE_REF  = f\"`{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}`\"\n",
+    "LOCATION   = os.environ.get(\"BQ_LOCATION\") or None  # e.g., \"us-central1\", None = auto\n",
     "\n",
     "# ---------- Required filters (top-level, every query) ----------\n",
     "TIME_RANGE_HOURS   = 720         # default: last 30 days\n",
@@ -192,7 +194,7 @@
     "SESSION_META_FILTERS   = None    # dict, e.g. {\"customer_id\": \"abc\"}\n",
     "\n",
     "# ---------- BigQuery client with session ----------\n",
-    "client = bigquery.Client(project=PROJECT_ID)\n",
+    "client = bigquery.Client(project=PROJECT_ID, location=LOCATION)\n",
     "\n",
     "# Create a session so CREATE TEMP TABLE works across cells\n",
     "_session_job = client.query(\n",
@@ -249,6 +251,7 @@
     "    return \" AND \".join(conds)\n",
     "\n",
     "print(f\"Project  : {PROJECT_ID}\")\n",
+    "print(f\"Location : {LOCATION or '(auto)'}\")\n",
     "print(f\"Dataset  : {DATASET_ID}\")\n",
     "print(f\"Table    : {TABLE_ID}\")\n",
     "print(f\"Time     : last {TIME_RANGE_HOURS} hours\")\n",
@@ -281,10 +284,10 @@
    "id": "cell-2-filtered",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:04:40.578301Z",
-     "iopub.status.busy": "2026-04-08T15:04:40.578129Z",
-     "iopub.status.idle": "2026-04-08T15:04:47.745977Z",
-     "shell.execute_reply": "2026-04-08T15:04:47.745198Z"
+     "iopub.execute_input": "2026-04-11T06:41:50.298254Z",
+     "iopub.status.busy": "2026-04-11T06:41:50.298069Z",
+     "iopub.status.idle": "2026-04-11T06:41:56.350076Z",
+     "shell.execute_reply": "2026-04-11T06:41:56.348840Z"
     }
    },
    "outputs": [
@@ -362,10 +365,10 @@
    "id": "cell-3-llm",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:04:47.748025Z",
-     "iopub.status.busy": "2026-04-08T15:04:47.747856Z",
-     "iopub.status.idle": "2026-04-08T15:04:53.086847Z",
-     "shell.execute_reply": "2026-04-08T15:04:53.085896Z"
+     "iopub.execute_input": "2026-04-11T06:41:56.352543Z",
+     "iopub.status.busy": "2026-04-11T06:41:56.352369Z",
+     "iopub.status.idle": "2026-04-11T06:42:01.619774Z",
+     "shell.execute_reply": "2026-04-11T06:42:01.618052Z"
     }
    },
    "outputs": [
@@ -440,10 +443,10 @@
    "id": "cell-4-tool",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:04:53.089460Z",
-     "iopub.status.busy": "2026-04-08T15:04:53.089286Z",
-     "iopub.status.idle": "2026-04-08T15:04:58.321365Z",
-     "shell.execute_reply": "2026-04-08T15:04:58.320223Z"
+     "iopub.execute_input": "2026-04-11T06:42:01.622630Z",
+     "iopub.status.busy": "2026-04-11T06:42:01.622434Z",
+     "iopub.status.idle": "2026-04-11T06:42:06.267905Z",
+     "shell.execute_reply": "2026-04-11T06:42:06.265200Z"
     }
    },
    "outputs": [
@@ -492,10 +495,10 @@
    "id": "cell-5-session",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:04:58.324170Z",
-     "iopub.status.busy": "2026-04-08T15:04:58.323991Z",
-     "iopub.status.idle": "2026-04-08T15:05:04.020896Z",
-     "shell.execute_reply": "2026-04-08T15:05:04.020092Z"
+     "iopub.execute_input": "2026-04-11T06:42:06.271245Z",
+     "iopub.status.busy": "2026-04-11T06:42:06.270992Z",
+     "iopub.status.idle": "2026-04-11T06:42:11.113316Z",
+     "shell.execute_reply": "2026-04-11T06:42:11.112639Z"
     }
    },
    "outputs": [
@@ -556,10 +559,10 @@
    "id": "cell-6-hitl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:05:04.022829Z",
-     "iopub.status.busy": "2026-04-08T15:05:04.022693Z",
-     "iopub.status.idle": "2026-04-08T15:05:32.032982Z",
-     "shell.execute_reply": "2026-04-08T15:05:32.032044Z"
+     "iopub.execute_input": "2026-04-11T06:42:11.115962Z",
+     "iopub.status.busy": "2026-04-11T06:42:11.115783Z",
+     "iopub.status.idle": "2026-04-11T06:42:16.813117Z",
+     "shell.execute_reply": "2026-04-11T06:42:16.812276Z"
     }
    },
    "outputs": [
@@ -613,10 +616,10 @@
    "id": "cell-7-multimodal",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:05:32.035886Z",
-     "iopub.status.busy": "2026-04-08T15:05:32.035687Z",
-     "iopub.status.idle": "2026-04-08T15:05:37.400668Z",
-     "shell.execute_reply": "2026-04-08T15:05:37.400219Z"
+     "iopub.execute_input": "2026-04-11T06:42:16.815696Z",
+     "iopub.status.busy": "2026-04-11T06:42:16.815508Z",
+     "iopub.status.idle": "2026-04-11T06:42:21.446270Z",
+     "shell.execute_reply": "2026-04-11T06:42:21.445378Z"
     }
    },
    "outputs": [
@@ -668,10 +671,10 @@
    "id": "cell-8-trace",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:05:37.402539Z",
-     "iopub.status.busy": "2026-04-08T15:05:37.402429Z",
-     "iopub.status.idle": "2026-04-08T15:05:42.146886Z",
-     "shell.execute_reply": "2026-04-08T15:05:42.145901Z"
+     "iopub.execute_input": "2026-04-11T06:42:21.449839Z",
+     "iopub.status.busy": "2026-04-11T06:42:21.449579Z",
+     "iopub.status.idle": "2026-04-11T06:42:26.384847Z",
+     "shell.execute_reply": "2026-04-11T06:42:26.382638Z"
     }
    },
    "outputs": [
@@ -728,10 +731,10 @@
    "id": "chart-helpers",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:05:42.149651Z",
-     "iopub.status.busy": "2026-04-08T15:05:42.149459Z",
-     "iopub.status.idle": "2026-04-08T15:05:42.163225Z",
-     "shell.execute_reply": "2026-04-08T15:05:42.162469Z"
+     "iopub.execute_input": "2026-04-11T06:42:26.387951Z",
+     "iopub.status.busy": "2026-04-11T06:42:26.387703Z",
+     "iopub.status.idle": "2026-04-11T06:42:26.400289Z",
+     "shell.execute_reply": "2026-04-11T06:42:26.399672Z"
     }
    },
    "outputs": [],
@@ -821,10 +824,10 @@
    "id": "cell-9-token-kpi",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:05:42.165040Z",
-     "iopub.status.busy": "2026-04-08T15:05:42.164908Z",
-     "iopub.status.idle": "2026-04-08T15:05:45.372732Z",
-     "shell.execute_reply": "2026-04-08T15:05:45.372185Z"
+     "iopub.execute_input": "2026-04-11T06:42:26.402876Z",
+     "iopub.status.busy": "2026-04-11T06:42:26.402735Z",
+     "iopub.status.idle": "2026-04-11T06:42:29.231801Z",
+     "shell.execute_reply": "2026-04-11T06:42:29.231279Z"
     }
    },
    "outputs": [
@@ -861,10 +864,10 @@
    "id": "cell-10-token-time",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:05:45.374347Z",
-     "iopub.status.busy": "2026-04-08T15:05:45.374247Z",
-     "iopub.status.idle": "2026-04-08T15:05:48.081376Z",
-     "shell.execute_reply": "2026-04-08T15:05:48.080957Z"
+     "iopub.execute_input": "2026-04-11T06:42:29.233099Z",
+     "iopub.status.busy": "2026-04-11T06:42:29.232998Z",
+     "iopub.status.idle": "2026-04-11T06:42:31.440202Z",
+     "shell.execute_reply": "2026-04-11T06:42:31.439703Z"
     }
    },
    "outputs": [
@@ -901,10 +904,10 @@
    "id": "cell-11-agent-tokens",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:05:48.083030Z",
-     "iopub.status.busy": "2026-04-08T15:05:48.082913Z",
-     "iopub.status.idle": "2026-04-08T15:05:50.651210Z",
-     "shell.execute_reply": "2026-04-08T15:05:50.650690Z"
+     "iopub.execute_input": "2026-04-11T06:42:31.441769Z",
+     "iopub.status.busy": "2026-04-11T06:42:31.441671Z",
+     "iopub.status.idle": "2026-04-11T06:42:33.836102Z",
+     "shell.execute_reply": "2026-04-11T06:42:33.835525Z"
     }
    },
    "outputs": [
@@ -944,10 +947,10 @@
    "id": "cell-12-user-tokens",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:05:50.652716Z",
-     "iopub.status.busy": "2026-04-08T15:05:50.652614Z",
-     "iopub.status.idle": "2026-04-08T15:05:53.218795Z",
-     "shell.execute_reply": "2026-04-08T15:05:53.218313Z"
+     "iopub.execute_input": "2026-04-11T06:42:33.837495Z",
+     "iopub.status.busy": "2026-04-11T06:42:33.837393Z",
+     "iopub.status.idle": "2026-04-11T06:42:36.221254Z",
+     "shell.execute_reply": "2026-04-11T06:42:36.220702Z"
     }
    },
    "outputs": [
@@ -995,10 +998,10 @@
    "id": "cell-13-usage-kpi",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:05:53.220408Z",
-     "iopub.status.busy": "2026-04-08T15:05:53.220305Z",
-     "iopub.status.idle": "2026-04-08T15:05:55.624474Z",
-     "shell.execute_reply": "2026-04-08T15:05:55.623792Z"
+     "iopub.execute_input": "2026-04-11T06:42:36.222975Z",
+     "iopub.status.busy": "2026-04-11T06:42:36.222853Z",
+     "iopub.status.idle": "2026-04-11T06:42:39.694967Z",
+     "shell.execute_reply": "2026-04-11T06:42:39.694409Z"
     }
    },
    "outputs": [
@@ -1037,10 +1040,10 @@
    "id": "cell-14-sessions-time",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:05:55.626108Z",
-     "iopub.status.busy": "2026-04-08T15:05:55.625992Z",
-     "iopub.status.idle": "2026-04-08T15:05:58.253900Z",
-     "shell.execute_reply": "2026-04-08T15:05:58.253466Z"
+     "iopub.execute_input": "2026-04-11T06:42:39.696560Z",
+     "iopub.status.busy": "2026-04-11T06:42:39.696441Z",
+     "iopub.status.idle": "2026-04-11T06:42:41.950269Z",
+     "shell.execute_reply": "2026-04-11T06:42:41.949828Z"
     }
    },
    "outputs": [
@@ -1070,10 +1073,10 @@
    "id": "cell-15-calls-time",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:05:58.255454Z",
-     "iopub.status.busy": "2026-04-08T15:05:58.255349Z",
-     "iopub.status.idle": "2026-04-08T15:06:01.333069Z",
-     "shell.execute_reply": "2026-04-08T15:06:01.332531Z"
+     "iopub.execute_input": "2026-04-11T06:42:41.951701Z",
+     "iopub.status.busy": "2026-04-11T06:42:41.951598Z",
+     "iopub.status.idle": "2026-04-11T06:42:44.324908Z",
+     "shell.execute_reply": "2026-04-11T06:42:44.324433Z"
     }
    },
    "outputs": [
@@ -1117,10 +1120,10 @@
    "id": "cell-16-error-kpi",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:01.334557Z",
-     "iopub.status.busy": "2026-04-08T15:06:01.334461Z",
-     "iopub.status.idle": "2026-04-08T15:06:03.846708Z",
-     "shell.execute_reply": "2026-04-08T15:06:03.846028Z"
+     "iopub.execute_input": "2026-04-11T06:42:44.326476Z",
+     "iopub.status.busy": "2026-04-11T06:42:44.326364Z",
+     "iopub.status.idle": "2026-04-11T06:42:47.139370Z",
+     "shell.execute_reply": "2026-04-11T06:42:47.138760Z"
     }
    },
    "outputs": [
@@ -1153,10 +1156,10 @@
    "id": "cell-17-errors-time",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:03.848257Z",
-     "iopub.status.busy": "2026-04-08T15:06:03.848144Z",
-     "iopub.status.idle": "2026-04-08T15:06:07.002140Z",
-     "shell.execute_reply": "2026-04-08T15:06:07.001132Z"
+     "iopub.execute_input": "2026-04-11T06:42:47.141102Z",
+     "iopub.status.busy": "2026-04-11T06:42:47.140987Z",
+     "iopub.status.idle": "2026-04-11T06:42:49.355343Z",
+     "shell.execute_reply": "2026-04-11T06:42:49.354075Z"
     }
    },
    "outputs": [
@@ -1201,10 +1204,10 @@
    "id": "cell-18-tool-errors",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:07.004885Z",
-     "iopub.status.busy": "2026-04-08T15:06:07.004708Z",
-     "iopub.status.idle": "2026-04-08T15:06:09.394988Z",
-     "shell.execute_reply": "2026-04-08T15:06:09.393462Z"
+     "iopub.execute_input": "2026-04-11T06:42:49.358277Z",
+     "iopub.status.busy": "2026-04-11T06:42:49.358056Z",
+     "iopub.status.idle": "2026-04-11T06:42:52.869401Z",
+     "shell.execute_reply": "2026-04-11T06:42:52.868956Z"
     }
    },
    "outputs": [
@@ -1245,10 +1248,10 @@
    "id": "cell-19-llm-errors",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:09.397759Z",
-     "iopub.status.busy": "2026-04-08T15:06:09.397559Z",
-     "iopub.status.idle": "2026-04-08T15:06:11.708804Z",
-     "shell.execute_reply": "2026-04-08T15:06:11.707757Z"
+     "iopub.execute_input": "2026-04-11T06:42:52.871055Z",
+     "iopub.status.busy": "2026-04-11T06:42:52.870925Z",
+     "iopub.status.idle": "2026-04-11T06:42:55.022684Z",
+     "shell.execute_reply": "2026-04-11T06:42:55.022059Z"
     }
    },
    "outputs": [
@@ -1293,10 +1296,10 @@
    "id": "cell-20-llm-latency",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:11.712140Z",
-     "iopub.status.busy": "2026-04-08T15:06:11.711937Z",
-     "iopub.status.idle": "2026-04-08T15:06:14.336707Z",
-     "shell.execute_reply": "2026-04-08T15:06:14.336203Z"
+     "iopub.execute_input": "2026-04-11T06:42:55.024688Z",
+     "iopub.status.busy": "2026-04-11T06:42:55.024558Z",
+     "iopub.status.idle": "2026-04-11T06:42:57.203301Z",
+     "shell.execute_reply": "2026-04-11T06:42:57.202807Z"
     }
    },
    "outputs": [
@@ -1334,10 +1337,10 @@
    "id": "cell-21-tool-latency",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:14.338184Z",
-     "iopub.status.busy": "2026-04-08T15:06:14.338089Z",
-     "iopub.status.idle": "2026-04-08T15:06:16.693807Z",
-     "shell.execute_reply": "2026-04-08T15:06:16.693225Z"
+     "iopub.execute_input": "2026-04-11T06:42:57.204637Z",
+     "iopub.status.busy": "2026-04-11T06:42:57.204560Z",
+     "iopub.status.idle": "2026-04-11T06:42:59.363587Z",
+     "shell.execute_reply": "2026-04-11T06:42:59.363052Z"
     }
    },
    "outputs": [
@@ -1382,10 +1385,10 @@
    "id": "cell-22-ttft",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:16.695434Z",
-     "iopub.status.busy": "2026-04-08T15:06:16.695332Z",
-     "iopub.status.idle": "2026-04-08T15:06:19.288374Z",
-     "shell.execute_reply": "2026-04-08T15:06:19.287787Z"
+     "iopub.execute_input": "2026-04-11T06:42:59.365070Z",
+     "iopub.status.busy": "2026-04-11T06:42:59.364963Z",
+     "iopub.status.idle": "2026-04-11T06:43:01.941448Z",
+     "shell.execute_reply": "2026-04-11T06:43:01.940887Z"
     }
    },
    "outputs": [
@@ -1431,10 +1434,10 @@
    "id": "cell-23-duration",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:19.289814Z",
-     "iopub.status.busy": "2026-04-08T15:06:19.289707Z",
-     "iopub.status.idle": "2026-04-08T15:06:21.897816Z",
-     "shell.execute_reply": "2026-04-08T15:06:21.897292Z"
+     "iopub.execute_input": "2026-04-11T06:43:01.942915Z",
+     "iopub.status.busy": "2026-04-11T06:43:01.942801Z",
+     "iopub.status.idle": "2026-04-11T06:43:04.497243Z",
+     "shell.execute_reply": "2026-04-11T06:43:04.496754Z"
     }
    },
    "outputs": [
@@ -1479,10 +1482,10 @@
    "id": "cell-24-users-time",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:21.899320Z",
-     "iopub.status.busy": "2026-04-08T15:06:21.899211Z",
-     "iopub.status.idle": "2026-04-08T15:06:24.670284Z",
-     "shell.execute_reply": "2026-04-08T15:06:24.669637Z"
+     "iopub.execute_input": "2026-04-11T06:43:04.498929Z",
+     "iopub.status.busy": "2026-04-11T06:43:04.498822Z",
+     "iopub.status.idle": "2026-04-11T06:43:06.610460Z",
+     "shell.execute_reply": "2026-04-11T06:43:06.609933Z"
     }
    },
    "outputs": [
@@ -1514,10 +1517,10 @@
    "id": "cell-25-top-users",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:24.671697Z",
-     "iopub.status.busy": "2026-04-08T15:06:24.671596Z",
-     "iopub.status.idle": "2026-04-08T15:06:27.482464Z",
-     "shell.execute_reply": "2026-04-08T15:06:27.481466Z"
+     "iopub.execute_input": "2026-04-11T06:43:06.612097Z",
+     "iopub.status.busy": "2026-04-11T06:43:06.611935Z",
+     "iopub.status.idle": "2026-04-11T06:43:08.814030Z",
+     "shell.execute_reply": "2026-04-11T06:43:08.813137Z"
     }
    },
    "outputs": [
@@ -1550,10 +1553,10 @@
    "id": "cell-26-agents-users",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:27.484948Z",
-     "iopub.status.busy": "2026-04-08T15:06:27.484719Z",
-     "iopub.status.idle": "2026-04-08T15:06:30.123690Z",
-     "shell.execute_reply": "2026-04-08T15:06:30.123106Z"
+     "iopub.execute_input": "2026-04-11T06:43:08.816538Z",
+     "iopub.status.busy": "2026-04-11T06:43:08.816390Z",
+     "iopub.status.idle": "2026-04-11T06:43:11.315453Z",
+     "shell.execute_reply": "2026-04-11T06:43:11.315029Z"
     }
    },
    "outputs": [
@@ -1600,10 +1603,10 @@
    "id": "cell-27-hitl-time",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:30.125402Z",
-     "iopub.status.busy": "2026-04-08T15:06:30.125295Z",
-     "iopub.status.idle": "2026-04-08T15:06:32.230096Z",
-     "shell.execute_reply": "2026-04-08T15:06:32.228609Z"
+     "iopub.execute_input": "2026-04-11T06:43:11.316939Z",
+     "iopub.status.busy": "2026-04-11T06:43:11.316844Z",
+     "iopub.status.idle": "2026-04-11T06:43:13.541111Z",
+     "shell.execute_reply": "2026-04-11T06:43:13.540383Z"
     }
    },
    "outputs": [
@@ -1649,10 +1652,10 @@
    "id": "cell-28-hitl-rate",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:32.233218Z",
-     "iopub.status.busy": "2026-04-08T15:06:32.233017Z",
-     "iopub.status.idle": "2026-04-08T15:06:35.057155Z",
-     "shell.execute_reply": "2026-04-08T15:06:35.056004Z"
+     "iopub.execute_input": "2026-04-11T06:43:13.543447Z",
+     "iopub.status.busy": "2026-04-11T06:43:13.543270Z",
+     "iopub.status.idle": "2026-04-11T06:43:15.699112Z",
+     "shell.execute_reply": "2026-04-11T06:43:15.697573Z"
     }
    },
    "outputs": [
@@ -1695,10 +1698,10 @@
    "id": "cell-29-invocations",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:35.059570Z",
-     "iopub.status.busy": "2026-04-08T15:06:35.059369Z",
-     "iopub.status.idle": "2026-04-08T15:06:37.576718Z",
-     "shell.execute_reply": "2026-04-08T15:06:37.576287Z"
+     "iopub.execute_input": "2026-04-11T06:43:15.701896Z",
+     "iopub.status.busy": "2026-04-11T06:43:15.701677Z",
+     "iopub.status.idle": "2026-04-11T06:43:17.858627Z",
+     "shell.execute_reply": "2026-04-11T06:43:17.857957Z"
     }
    },
    "outputs": [
@@ -1741,10 +1744,10 @@
    "id": "cell-30-multimodal-time",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:37.578393Z",
-     "iopub.status.busy": "2026-04-08T15:06:37.578298Z",
-     "iopub.status.idle": "2026-04-08T15:06:39.900608Z",
-     "shell.execute_reply": "2026-04-08T15:06:39.900167Z"
+     "iopub.execute_input": "2026-04-11T06:43:17.860278Z",
+     "iopub.status.busy": "2026-04-11T06:43:17.860176Z",
+     "iopub.status.idle": "2026-04-11T06:43:20.168642Z",
+     "shell.execute_reply": "2026-04-11T06:43:20.168041Z"
     }
    },
    "outputs": [
@@ -1794,10 +1797,10 @@
    "id": "cell-31-truncation",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:39.902187Z",
-     "iopub.status.busy": "2026-04-08T15:06:39.902084Z",
-     "iopub.status.idle": "2026-04-08T15:06:44.569653Z",
-     "shell.execute_reply": "2026-04-08T15:06:44.569134Z"
+     "iopub.execute_input": "2026-04-11T06:43:20.170032Z",
+     "iopub.status.busy": "2026-04-11T06:43:20.169933Z",
+     "iopub.status.idle": "2026-04-11T06:43:25.298548Z",
+     "shell.execute_reply": "2026-04-11T06:43:25.298088Z"
     }
    },
    "outputs": [
@@ -1875,10 +1878,10 @@
    "id": "cell-32-session-list",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:44.571122Z",
-     "iopub.status.busy": "2026-04-08T15:06:44.571025Z",
-     "iopub.status.idle": "2026-04-08T15:06:47.221474Z",
-     "shell.execute_reply": "2026-04-08T15:06:47.220589Z"
+     "iopub.execute_input": "2026-04-11T06:43:25.300060Z",
+     "iopub.status.busy": "2026-04-11T06:43:25.299962Z",
+     "iopub.status.idle": "2026-04-11T06:43:27.480800Z",
+     "shell.execute_reply": "2026-04-11T06:43:27.479850Z"
     }
    },
    "outputs": [
@@ -1924,10 +1927,10 @@
    "id": "cell-33-span-tree",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:47.224256Z",
-     "iopub.status.busy": "2026-04-08T15:06:47.224084Z",
-     "iopub.status.idle": "2026-04-08T15:06:50.016768Z",
-     "shell.execute_reply": "2026-04-08T15:06:50.015570Z"
+     "iopub.execute_input": "2026-04-11T06:43:27.482970Z",
+     "iopub.status.busy": "2026-04-11T06:43:27.482808Z",
+     "iopub.status.idle": "2026-04-11T06:43:29.823881Z",
+     "shell.execute_reply": "2026-04-11T06:43:29.823061Z"
     }
    },
    "outputs": [
@@ -2049,10 +2052,10 @@
    "id": "cell-34-span-detail",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:50.019400Z",
-     "iopub.status.busy": "2026-04-08T15:06:50.019232Z",
-     "iopub.status.idle": "2026-04-08T15:06:52.472863Z",
-     "shell.execute_reply": "2026-04-08T15:06:52.471944Z"
+     "iopub.execute_input": "2026-04-11T06:43:29.826544Z",
+     "iopub.status.busy": "2026-04-11T06:43:29.826303Z",
+     "iopub.status.idle": "2026-04-11T06:43:31.872350Z",
+     "shell.execute_reply": "2026-04-11T06:43:31.871827Z"
     }
    },
    "outputs": [
@@ -2200,10 +2203,10 @@
    "id": "cell-35-error-chain",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:52.475827Z",
-     "iopub.status.busy": "2026-04-08T15:06:52.475655Z",
-     "iopub.status.idle": "2026-04-08T15:06:54.564166Z",
-     "shell.execute_reply": "2026-04-08T15:06:54.562546Z"
+     "iopub.execute_input": "2026-04-11T06:43:31.873853Z",
+     "iopub.status.busy": "2026-04-11T06:43:31.873760Z",
+     "iopub.status.idle": "2026-04-11T06:43:33.810611Z",
+     "shell.execute_reply": "2026-04-11T06:43:33.809674Z"
     }
    },
    "outputs": [
@@ -2277,10 +2280,10 @@
    "id": "cell-closing",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-08T15:06:54.567508Z",
-     "iopub.status.busy": "2026-04-08T15:06:54.567273Z",
-     "iopub.status.idle": "2026-04-08T15:06:55.097167Z",
-     "shell.execute_reply": "2026-04-08T15:06:55.096043Z"
+     "iopub.execute_input": "2026-04-11T06:43:33.813173Z",
+     "iopub.status.busy": "2026-04-11T06:43:33.812996Z",
+     "iopub.status.idle": "2026-04-11T06:43:34.320329Z",
+     "shell.execute_reply": "2026-04-11T06:43:34.319454Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
## Summary

- Add `LOCATION = os.environ.get("BQ_LOCATION") or None` to the Dashboard V2 config block
- Pass `location=LOCATION` to `bigquery.Client()` so BQ sessions work for non-US dataset locations
- Print location in the config summary (`Location : (auto)` when unset)
- Consistent with the SDK's own `Client(location=None)` default (`client.py:317`)

Closes #76 (location configurability item only — BigFrames companion notebook is a separate exploratory issue per discussion on the issue thread).

## Test plan

- [x] Notebook re-executed end-to-end with `LOCATION=None` (auto) — session creation and all temp tables succeed
- [ ] Verify with a non-US dataset (e.g., `asia-northeast1`) by setting `BQ_LOCATION=asia-northeast1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)