### PR TITLE
docs: overhaul README and add documentation indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,65 @@
 # BigQuery Agent Analytics SDK
 
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/python-3.10%20|%203.11%20|%203.12%20|%203.13-blue)](pyproject.toml)
+[![CI](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/actions/workflows/ci.yml/badge.svg)](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/actions/workflows/ci.yml)
+
 An open-source Python SDK for analyzing, evaluating, and curating agent traces
 stored in BigQuery. Built on top of the
 [Agent Development Kit (ADK)](https://github.com/google/adk-python), it provides
 a consumption-layer toolkit for agent observability at scale.
 
-## Features
+## Overview
 
-- **Trace Reconstruction** -- Retrieve and visualize agent conversation DAGs
-- **Code-Based Evaluation** -- Deterministic metrics (latency, turn count,
-  error rate, token efficiency, cost)
-- **LLM-as-Judge** -- Semantic evaluation using LLM scoring (correctness,
-  hallucination, sentiment)
-- **Trajectory Matching** -- Exact, in-order, and any-order tool call matching
-- **Multi-Trial Evaluation** -- Run N trials with pass@k / pass^k metrics for
-  non-deterministic agents
-- **Grader Composition** -- Combine code + LLM graders via weighted, binary, or
-  majority strategies
-- **Eval Suite Management** -- Lifecycle management with graduation, saturation
-  detection, and balance checking
-- **Eval Quality Validation** -- Static checks for ambiguous tasks, class
-  imbalance, and suspicious thresholds
-- **Drift Detection** -- Compare golden vs production question distributions
-- **Agent Insights** -- Multi-stage pipeline for comprehensive session analysis
-- **Long-Horizon Memory** -- Cross-session context and semantic search
-- **BigQuery AI/ML Integration** -- AI.GENERATE, embeddings, anomaly detection,
-  latency forecasting
-- **Context Graph** -- Property Graph linking technical traces to business
-  entities, with GQL traversal, world-change detection, and artifact lineage
+The BigQuery Agent Analytics SDK connects your AI agent telemetry in BigQuery to
+a rich set of evaluation, observability, and analytics capabilities. It is
+designed for ML engineers, data scientists, and platform teams who run agents in
+production and need to understand agent behavior, measure quality, and detect
+regressions — all through BigQuery SQL or Python.
+
+## Key Features
+
+**Observability**
+- Trace reconstruction and DAG visualization
+- Per-event-type BigQuery views
+- Observability dashboards (SQL and BigFrames)
+
+**Evaluation**
+- Code-based metrics (latency, turn count, error rate, token efficiency, cost)
+- LLM-as-Judge scoring (correctness, hallucination, sentiment)
+- Trajectory matching (exact, in-order, any-order)
+- Multi-trial evaluation with pass@k / pass^k
+- Grader composition (weighted, binary, majority strategies)
+- Eval suite lifecycle management with graduation and saturation detection
+- Static quality validation (ambiguous tasks, class imbalance, suspicious thresholds)
+
+**AI/ML Integration**
+- BigQuery AI.GENERATE, AI.EMBED, AI.CLASSIFY
+- Anomaly detection and latency forecasting
+- Categorical (Hatteras-style) evaluation via BigFrames
+
+**Advanced Analytics**
+- Context Graph — property graph linking traces to business entities with GQL traversal
+- YAML-driven ontology extraction and materialization
+- Long-horizon cross-session memory
+- Multi-stage agent insights pipeline
+- Drift detection for golden vs production question distributions
+
+**CLI** (`bq-agent-sdk`)
+- 12+ commands for diagnostics, evaluation, and CI/CD integration
+
+**Deployment Surfaces**
+- Remote Function (BigQuery SQL via Cloud Run)
+- Python UDF scoring kernels
+- Streaming evaluation (Cloud Scheduler + Cloud Run)
+- Continuous query templates
+
+## Prerequisites
+
+- Python 3.10+
+- A Google Cloud project with BigQuery enabled
+- Agent traces stored in BigQuery via the
+  [ADK BigQuery Trace Exporter](https://github.com/google/adk-python)
 
 ## Installation
 
@@ -57,177 +89,73 @@ trace = client.get_trace("trace-abc-123")
 trace.render()
 ```
 
-### Code-Based Evaluation
+See [SDK.md](SDK.md) for the full API walkthrough with code examples for every
+feature.
 
-```python
-from bigquery_agent_analytics import CodeEvaluator
+## Documentation
 
-evaluator = CodeEvaluator.latency(threshold_ms=5000)
-score = evaluator.evaluate_session({
-    "session_id": "s1",
-    "avg_latency_ms": 2000,
-})
-print(score.passed)  # True
-```
-
-### Multi-Trial Evaluation
-
-```python
-from bigquery_agent_analytics import BigQueryTraceEvaluator, TrialRunner
-
-evaluator = BigQueryTraceEvaluator(
-    project_id="my-project",
-    dataset_id="analytics",
-)
-runner = TrialRunner(evaluator, num_trials=5)
-
-report = await runner.run_trials(
-    session_id="sess-123",
-    golden_trajectory=[{"tool_name": "search", "args": {}}],
-)
-print(f"pass@k: {report.pass_at_k}, pass^k: {report.pass_pow_k}")
-```
-
-### Grader Pipeline
-
-```python
-from bigquery_agent_analytics import (
-    CodeEvaluator, GraderPipeline, LLMAsJudge, WeightedStrategy,
-)
-
-pipeline = (
-    GraderPipeline(WeightedStrategy(
-        weights={"latency_evaluator": 0.3, "correctness_judge": 0.7},
-    ))
-    .add_code_grader(CodeEvaluator.latency())
-    .add_llm_grader(LLMAsJudge.correctness())
-)
-
-verdict = await pipeline.evaluate(
-    session_summary={"session_id": "s1", "avg_latency_ms": 2000},
-    trace_text="User: hello\nAgent: hi",
-    final_response="hi",
-)
-```
-
-### Eval Suite Management
-
-```python
-from bigquery_agent_analytics import EvalCategory, EvalSuite, EvalTaskDef
-
-suite = EvalSuite(name="my_agent_evals")
-suite.add_task(EvalTaskDef(
-    task_id="t1",
-    session_id="sess-123",
-    description="Test basic search",
-    expected_trajectory=[{"tool_name": "search", "args": {}}],
-))
-
-health = suite.check_health()
-print(health.warnings)
-
-# Auto-graduate stable tasks to regression
-graduated = suite.auto_graduate(pass_history, threshold_runs=10)
-```
-
-### CLI Quick Start
-
-The SDK includes a CLI for diagnostics, evaluation, and analytics:
-
-```bash
-# Health check
-bq-agent-sdk doctor --project-id=P --dataset-id=D
-
-# Retrieve a trace
-bq-agent-sdk get-trace --project-id=P --dataset-id=D --session-id=S
-
-# Run evaluation (CI gate with --exit-code)
-bq-agent-sdk evaluate --project-id=P --dataset-id=D \
-  --evaluator=latency --exit-code
-
-# Generate insights
-bq-agent-sdk insights --project-id=P --dataset-id=D --last=7d
-
-# All 10 commands: doctor, get-trace, evaluate, insights, drift,
-# distribution, hitl-metrics, list-traces, views create-all, views create
-```
-
-Set `BQ_AGENT_PROJECT` and `BQ_AGENT_DATASET` environment variables to
-skip `--project-id` and `--dataset-id` on every call.
-
-### Remote Function (BigQuery SQL)
-
-Deploy the SDK as a BigQuery Remote Function for SQL-native access:
-
-```bash
-cd deploy/remote_function
-./deploy.sh my-project us-central1 agent_analytics US
-```
-
-Then query from SQL (using the fully-qualified name from `register.sql`):
-
-```sql
-SELECT `my-project.agent_analytics.agent_analytics`(
-  'analyze', JSON'{"session_id": "s1"}'
-);
-SELECT `my-project.agent_analytics.agent_analytics`(
-  'evaluate', JSON'{"metric": "latency"}'
-);
-```
-
-See [SDK.md](SDK.md) for the full CLI reference, Remote Function API,
-and continuous query templates.
-
-### Streaming Evaluation
-
-Deploy a dedicated Cloud Run worker that scans recent `agent_events`
-rows every `5` minutes through `Cloud Scheduler -> SDK -> BigQuery`:
-
-```mermaid
-flowchart LR
-  A["agent_events"] --> B["Cloud Scheduler"]
-  B --> C["Cloud Run worker"]
-  C --> D["overlap scan + dedupe + checkpoint"]
-  D --> E["streaming_evaluation_results"]
-```
-
-Quick start:
-
-```bash
-cd deploy/streaming_evaluation
-./setup.sh up my-project my_dataset agent_events us-central1
-```
-
-Use [deploy/streaming_evaluation/README.md](deploy/streaming_evaluation/README.md)
-for the full setup flow. This path intentionally avoids continuous-query
-reservations because they can be too expensive as a default deployment
-mode.
+| Resource | Description |
+|----------|-------------|
+| [SDK Feature Reference](SDK.md) | Complete API walkthrough with working code examples |
+| [Design Documents](docs/README.md) | Architecture decisions and design rationale |
+| [Examples](examples/README.md) | Notebooks, SQL scripts, and demos |
+| [Deployment Guides](deploy/README.md) | Four deployment surfaces for Google Cloud |
 
 ## Architecture
 
 ```
-bigquery_agent_analytics/
-├── __init__.py              # Package exports
-├── client.py                # High-level SDK client
-├── evaluators.py            # CodeEvaluator + LLMAsJudge
-├── trace.py                 # Trace reconstruction & visualization
-├── trace_evaluator.py       # Trajectory matching & replay
-├── multi_trial.py           # Multi-trial runner + pass@k
-├── grader_pipeline.py       # Grader composition pipeline
-├── eval_suite.py            # Eval suite lifecycle management
-├── eval_validator.py        # Static validation checks
-├── feedback.py              # Drift detection & question distribution
-├── insights.py              # Multi-stage insights pipeline
-├── memory_service.py        # Long-horizon agent memory
-├── ai_ml_integration.py     # BigQuery AI/ML capabilities
-├── bigframes_evaluator.py   # BigFrames DataFrame evaluator
-├── context_graph.py         # Property Graph: BizNode extraction, GQL, world-change
-├── event_semantics.py       # Canonical event type helpers & predicates
-├── views.py                 # Per-event-type BigQuery view management
-├── cli.py                   # CLI entry point (bq-agent-sdk)
-├── formatter.py             # Output formatting (json/text/table)
-└── serialization.py         # Uniform serialization layer
+src/bigquery_agent_analytics/
+│
+├── Core
+│   ├── client.py                  # High-level SDK client
+│   ├── trace.py                   # Trace reconstruction & visualization
+│   ├── views.py                   # Per-event-type BigQuery view management
+│   ├── event_semantics.py         # Canonical event type helpers & predicates
+│   ├── serialization.py           # Uniform serialization layer
+│   └── formatter.py               # Output formatting (json/text/table)
+│
+├── Evaluation
+│   ├── evaluators.py              # CodeEvaluator + LLMAsJudge
+│   ├── trace_evaluator.py         # Trajectory matching & replay
+│   ├── multi_trial.py             # Multi-trial runner + pass@k
+│   ├── grader_pipeline.py         # Grader composition pipeline
+│   ├── eval_suite.py              # Eval suite lifecycle management
+│   └── eval_validator.py          # Static validation checks
+│
+├── AI/ML
+│   ├── ai_ml_integration.py       # BigQuery AI/ML capabilities
+│   ├── bigframes_evaluator.py     # BigFrames DataFrame evaluator
+│   ├── categorical_evaluator.py   # Hatteras categorical evaluation
+│   └── categorical_views.py       # Categorical metric views
+│
+├── Analytics
+│   ├── insights.py                # Multi-stage insights pipeline
+│   ├── feedback.py                # Drift detection & question distribution
+│   ├── context_graph.py           # Property Graph: BizNode extraction, GQL
+│   └── memory_service.py          # Long-horizon agent memory
+│
+├── Ontology
+│   ├── ontology_models.py         # Pydantic models for ontology schema
+│   ├── ontology_schema_compiler.py# YAML → compiled schema
+│   ├── ontology_graph.py          # Ontology graph construction
+│   ├── ontology_materializer.py   # Graph materialization to BigQuery
+│   ├── ontology_property_graph.py # Property graph operations
+│   └── ontology_orchestrator.py   # End-to-end ontology pipeline
+│
+└── CLI & Deploy
+    ├── cli.py                     # CLI entry point (bq-agent-sdk)
+    ├── udf_kernels.py             # Python UDF scoring kernels
+    └── udf_sql_templates.py       # UDF SQL generation
 ```
+
+## Related Projects
+
+- [Google ADK](https://github.com/google/adk-python) — Agent Development Kit
+  for building AI agents
+- [BigQuery](https://cloud.google.com/bigquery) — Google Cloud analytics data
+  warehouse
+- [BigQuery AI Functions](https://cloud.google.com/bigquery/docs/ai-application-overview) —
+  AI.GENERATE, AI.EMBED, AI.CLASSIFY, and more
 
 ## Development
 
@@ -245,4 +173,10 @@ isort src/ tests/
 
 ## License
 
-Apache License 2.0 -- see [LICENSE](LICENSE) for details.
+Apache License 2.0 — see [LICENSE](LICENSE) for details.
+
+## Disclaimer
+
+This is not an officially supported Google product. This SDK is intended to
+demonstrate patterns for analyzing agent traces in BigQuery and is provided
+as-is.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,14 @@
+# Deployment Guides
+
+This directory contains four deployment surfaces for running SDK capabilities
+inside Google Cloud infrastructure. For the CLI (`bq-agent-sdk`), see
+[SDK.md](../SDK.md).
+
+| Surface | Directory | Description |
+|---------|-----------|-------------|
+| Remote Function | [remote_function/](remote_function/) | BigQuery SQL-native access via Cloud Run |
+| Python UDF | [python_udf/](python_udf/) | BigQuery Python UDF scoring kernels |
+| Streaming Evaluation | [streaming_evaluation/](streaming_evaluation/) | Cloud Scheduler + Cloud Run incremental eval |
+| Continuous Queries | [continuous_queries/](continuous_queries/) | Real-time BigQuery continuous query templates |
+
+Each subdirectory contains a README with setup instructions.

--- a/deploy/continuous_queries/README.md
+++ b/deploy/continuous_queries/README.md
@@ -1,0 +1,49 @@
+# Continuous Queries Deployment
+
+Run real-time evaluation and alerting as agent events arrive in BigQuery using
+continuous queries.
+
+## What It Does
+
+Continuous queries run perpetually against a BigQuery table, processing new rows
+as they are inserted. The templates in this directory apply SDK evaluation logic,
+error detection, and alerting in real time.
+
+## Prerequisites
+
+- A BigQuery Enterprise or Enterprise Plus reservation with continuous query
+  slots — see [setup_reservation.md](setup_reservation.md) for setup
+- A BigQuery dataset containing `agent_events`
+
+> **Cost note:** Enterprise reservations are billed per slot-hour (100 slots
+> ≈ $6/hour). For a lower-cost alternative, see
+> [streaming_evaluation/](../streaming_evaluation/).
+
+## Templates
+
+| Template | Description |
+|----------|-------------|
+| [session_scoring.sql](session_scoring.sql) | Live session quality scoring |
+| [realtime_error_analysis.sql](realtime_error_analysis.sql) | Real-time error detection and classification |
+| [pubsub_alerting.sql](pubsub_alerting.sql) | Pub/Sub event alerting |
+| [bigtable_dashboard.sql](bigtable_dashboard.sql) | Bigtable metrics aggregation for dashboards |
+
+## Activate a Template
+
+1. Set up the reservation ([setup_reservation.md](setup_reservation.md))
+2. Replace `PROJECT`, `DATASET`, and `REGION` placeholders in the chosen SQL file
+3. Run with the continuous flag:
+
+```bash
+bq query --use_legacy_sql=false --continuous=true < session_scoring.sql
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `setup_reservation.md` | Enterprise reservation setup guide |
+| `session_scoring.sql` | Session quality scoring template |
+| `realtime_error_analysis.sql` | Error detection template |
+| `pubsub_alerting.sql` | Pub/Sub alerting template |
+| `bigtable_dashboard.sql` | Bigtable aggregation template |

--- a/deploy/remote_function/README.md
+++ b/deploy/remote_function/README.md
@@ -1,0 +1,71 @@
+# Remote Function Deployment
+
+Deploy the SDK as a BigQuery Remote Function so you can call it from SQL.
+
+## What It Does
+
+Exposes the SDK as a Cloud Function (gen2) behind a BigQuery remote function.
+Once registered, you can run SDK operations — trace analysis, evaluation, and
+more — directly from BigQuery SQL.
+
+## Prerequisites
+
+- `gcloud` CLI authenticated with sufficient permissions
+- Cloud Functions API and Cloud Build API enabled
+- A BigQuery dataset to host the function
+
+## Deploy
+
+```bash
+cd deploy/remote_function
+./deploy.sh PROJECT [FUNCTION_REGION] [DATASET] [BQ_LOCATION]
+```
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `PROJECT` | *required* | GCP project ID |
+| `FUNCTION_REGION` | `us-central1` | Cloud Function region |
+| `DATASET` | `agent_analytics` | BigQuery dataset for the function |
+| `BQ_LOCATION` | `US` | BigQuery dataset location (must match the dataset) |
+
+The script builds an SDK wheel from the repo, stages a deployment bundle, deploys
+the Cloud Function, creates a BigQuery CLOUD_RESOURCE connection, and grants the
+invoker role.
+
+## Register the Function
+
+After deployment, register the remote function in BigQuery. Replace the
+placeholders in `register.sql` and run it, or copy the DDL printed by
+`deploy.sh`.
+
+```sql
+CREATE OR REPLACE FUNCTION `PROJECT.DATASET.agent_analytics`(
+  operation STRING, params JSON
+) RETURNS JSON
+REMOTE WITH CONNECTION `PROJECT.BQ_LOCATION.analytics-conn`
+OPTIONS (
+  endpoint = 'https://FUNCTION_REGION-PROJECT.cloudfunctions.net/bq-agent-analytics',
+  max_batching_rows = 50
+);
+```
+
+## Usage
+
+```sql
+SELECT `my-project.agent_analytics.agent_analytics`(
+  'analyze', JSON '{"session_id": "s1"}'
+);
+
+SELECT `my-project.agent_analytics.agent_analytics`(
+  'evaluate', JSON '{"metric": "latency"}'
+);
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `deploy.sh` | End-to-end deploy script (build, stage, deploy, connect) |
+| `main.py` | Cloud Function entry point |
+| `dispatch.py` | Request routing and SDK dispatch |
+| `register.sql` | DDL template for registering the remote function |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,34 @@
+# Design Documents
+
+This directory contains design documents and proposals that describe the
+architecture, rationale, and implementation plans behind key SDK features.
+
+## Architecture & Vision
+
+| Document | Description |
+|----------|-------------|
+| [design.md](design.md) | Original SDK architecture and design rationale |
+| [prd_unified_analytics_interface.md](prd_unified_analytics_interface.md) | PRD for unified analytics interface |
+
+## Evaluation
+
+| Document | Description |
+|----------|-------------|
+| [hatteras_evaluation.md](hatteras_evaluation.md) | Hatteras-style categorical evaluation design |
+
+## Context & Ontology
+
+| Document | Description |
+|----------|-------------|
+| [context_graph_v2_design.md](context_graph_v2_design.md) | Property Graph V2 design |
+| [context_graph_v3_design.md](context_graph_v3_design.md) | Property Graph V3 with GQL and world-change detection |
+| [ontology_graph_v4_design.md](ontology_graph_v4_design.md) | YAML-driven ontology extraction and materialization |
+
+## Deployment Surfaces
+
+| Document | Description |
+|----------|-------------|
+| [proposal_bigquery_agent_cli.md](proposal_bigquery_agent_cli.md) | CLI proposal and command design |
+| [python_udf_support_design.md](python_udf_support_design.md) | BigQuery Python UDF architecture |
+| [remote_function_rationale.md](remote_function_rationale.md) | Cloud Run remote function rationale |
+| [implementation_plan_remote_function.md](implementation_plan_remote_function.md) | Remote function implementation plan |

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,63 @@
+# Examples
+
+This directory contains notebooks, SQL scripts, Python demos, and reference
+artifacts that demonstrate SDK capabilities.
+
+## Notebooks
+
+| Notebook | Description |
+|----------|-------------|
+| [dashboard_v2.ipynb](dashboard_v2.ipynb) | Observability dashboard (2-layer SQL, no SDK dependency) |
+| [dashboard_v2_bigframes.ipynb](dashboard_v2_bigframes.ipynb) | BigFrames companion for Dashboard V2 |
+| [e2e_notebook_demo.ipynb](e2e_notebook_demo.ipynb) | End-to-end SDK workflow |
+| [ai_ml_integration_demo.ipynb](ai_ml_integration_demo.ipynb) | AI.GENERATE, AI.EMBED, anomaly detection |
+| [categorical_evaluation_demo.ipynb](categorical_evaluation_demo.ipynb) | Hatteras categorical evaluation |
+| [context_graph_adcp_demo.ipynb](context_graph_adcp_demo.ipynb) | Property Graph use cases |
+| [ontology_graph_v4_demo.ipynb](ontology_graph_v4_demo.ipynb) | Ontology extraction + GQL |
+| [memory_service_demo.ipynb](memory_service_demo.ipynb) | Cross-session memory |
+| [event_semantics_views_bigframes_demo.ipynb](event_semantics_views_bigframes_demo.ipynb) | Event views + BigFrames |
+| [nba_agent_trace_analysis_notebook.ipynb](nba_agent_trace_analysis_notebook.ipynb) | Real-world trace analysis |
+
+## SQL — BigQuery AI Operators
+
+| File | Description |
+|------|-------------|
+| [ai_classify_side_by_side.sql](ai_classify_side_by_side.sql) | AI.CLASSIFY vs AI.GENERATE comparison |
+| [ai_forecast_side_by_side.sql](ai_forecast_side_by_side.sql) | AI.FORECAST vs ML.FORECAST comparison |
+| [ai_similarity_validation.sql](ai_similarity_validation.sql) | AI.SIMILARITY vs AI.EMBED + ML.DISTANCE |
+
+## SQL — Deployment Surfaces
+
+| File | Description |
+|------|-------------|
+| [categorical_dashboard.sql](categorical_dashboard.sql) | Categorical metrics dashboard queries |
+| [python_udf_evaluation.sql](python_udf_evaluation.sql) | UDF-based evaluation queries |
+| [python_udf_eval_summary.sql](python_udf_eval_summary.sql) | UDF summary metrics |
+| [python_udf_event_semantics.sql](python_udf_event_semantics.sql) | Event semantic UDFs |
+| [remote_function_dashboard.sql](remote_function_dashboard.sql) | Remote function queries |
+| [continuous_query_alerting.sql](continuous_query_alerting.sql) | Continuous query patterns |
+
+## Python Scripts
+
+| File | Description |
+|------|-------------|
+| [e2e_demo.py](e2e_demo.py) | Complete end-to-end workflow |
+| [cli_agent_tool.py](cli_agent_tool.py) | CLI agent tool example |
+| [ci_eval_pipeline.sh](ci_eval_pipeline.sh) | CI evaluation pipeline |
+
+## HTML Demos
+
+Pre-rendered notebook output for viewing without Jupyter.
+
+| File | Description |
+|------|-------------|
+| [context_graph_v2_demo.html](context_graph_v2_demo.html) | Context Graph V2 rendered demo |
+| [decision_semantics_demo.html](decision_semantics_demo.html) | Decision semantics rendered demo |
+| [ontology_graph_v4_demo.html](ontology_graph_v4_demo.html) | Ontology Graph V4 rendered demo |
+
+## Reference Artifacts
+
+| File | Description |
+|------|-------------|
+| [e2e_demo_output.txt](e2e_demo_output.txt) | Expected output from e2e_demo.py |
+| [ymgo_graph_spec.yaml](ymgo_graph_spec.yaml) | Example ontology YAML specification |


### PR DESCRIPTION
## Summary

- **Rewrite root README** — add badges (license, Python, CI), group features into logical categories, add prerequisites section, reduce inline code to one quick-start snippet, add documentation index table, show logical architecture diagram, add related projects and disclaimer
- **Create `docs/README.md`** — categorized index of all 10 design documents
- **Create `examples/README.md`** — categorized index of all 27 examples (notebooks, SQL, scripts, HTML demos, reference artifacts)
- **Create `deploy/README.md`** — index of 4 deployment surfaces
- **Create `deploy/remote_function/README.md`** — setup guide with deploy command, registration DDL, and usage examples
- **Create `deploy/continuous_queries/README.md`** — guide with prerequisites, cost note, template descriptions, and activation instructions

No source code, tests, or pyproject.toml changes.

## Test plan

- [ ] All internal markdown links resolve to existing files (verified locally)
- [ ] Badge URLs point to correct repo paths
- [ ] Renders correctly in GitHub markdown preview