### PR TITLE
docs: add ontology reference docs to docs/ontology/

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,17 @@ architecture, rationale, and implementation plans behind key SDK features.
 | [context_graph_v2_design.md](context_graph_v2_design.md) | Property Graph V2 design |
 | [context_graph_v3_design.md](context_graph_v3_design.md) | Property Graph V3 with GQL and world-change detection |
 | [ontology_graph_v4_design.md](ontology_graph_v4_design.md) | YAML-driven ontology extraction and materialization |
+| [learning_ontology_and_context_graph.md](learning_ontology_and_context_graph.md) | Learning guide for ontology and context graph |
+
+## Ontology Reference
+
+| Document | Description |
+|----------|-------------|
+| [ontology/ontology.md](ontology/ontology.md) | Ontology core design — logical ontology spec |
+| [ontology/binding.md](ontology/binding.md) | Binding design — attaching ontology to physical tables |
+| [ontology/compilation.md](ontology/compilation.md) | Compilation — resolving ontology + binding into backend DDL |
+| [ontology/cli.md](ontology/cli.md) | CLI design for the `gm` tool (validate, compile, import-owl) |
+| [ontology/owl-import.md](ontology/owl-import.md) | OWL import — converting OWL ontologies to YAML format |
 
 ## Deployment Surfaces
 

--- a/docs/ontology/binding.md
+++ b/docs/ontology/binding.md
@@ -1,0 +1,286 @@
+# Binding — Core Design (v0)
+
+Status: draft
+Scope: the binding spec only — the YAML format that attaches a logical
+ontology (see `ontology.md`) to physical tables and columns on a specific
+backend.
+
+## 1. Goals
+
+- **Thin files.** A binding says *where* data lives, not *how* it is
+  transformed.
+- **One file per target.** One binding file per target, e.g. `(backend, deployment env)` pair. No conditional logic inside a file.
+- **Backend-neutral shape.** Entity and relationship binding syntax is
+  identical for BigQuery and Spanner; only the `target:` block differs.
+- **Ontology-aware, ontology-unaware.** The binding references ontology
+  names and never redeclares logical structure. The ontology file does not
+  know bindings exist.
+
+## 2. File shape
+
+One file per target. Suffix: `*.binding.yaml`. Top-level key: `binding:`.
+All YAML uses block style; flow style is equivalent.
+
+```yaml
+binding: finance-bq-prod
+ontology: finance
+target:
+  backend: bigquery
+  project: my-proj
+  dataset: finance
+
+entities:
+  - name: Person
+    source: raw.persons
+    properties:
+      - name: party_id
+        column: person_id
+      - name: name
+        column: display_name
+      - name: dob
+        column: date_of_birth
+      - name: first_name
+        column: given_name
+      - name: last_name
+        column: family_name
+      # full_name is derived (expr in ontology) — not listed here
+
+  - name: Organization
+    source: raw.organizations
+    properties:
+      - name: party_id
+        column: org_id
+      - name: name
+        column: legal_name
+      - name: tax_id
+        column: ein
+
+  - name: Account
+    source: raw.accounts
+    properties:
+      - name: account_id
+        column: acct_id
+      - name: opened_at
+        column: created_ts
+
+  - name: Security
+    source: ref.securities
+    properties:
+      - name: security_id
+        column: cusip
+
+relationships:
+  - name: HOLDS
+    source: raw.holdings
+    from_columns:
+      - account_id
+    to_columns:
+      - security_id
+    properties:
+      - name: as_of
+        column: snapshot_date
+      - name: quantity
+        column: qty
+
+  - name: TRANSFER
+    source: raw.transactions
+    from_columns:
+      - src_account
+    to_columns:
+      - dst_account
+    properties:
+      - name: transaction_id
+        column: txn_id
+      - name: amount
+        column: amount_usd
+      - name: executed_at
+        column: executed_ts
+```
+
+## 2a. Type overview
+
+```yaml
+# Binding  (top-level)
+binding: <string>                       # required
+ontology: <string>                      # required, must match the ontology's `ontology:` field
+target: <Target>                        # required
+entities: [<EntityBinding>, ...]        # optional
+relationships: [<RelationshipBinding>, ...]  # optional
+```
+
+```yaml
+# Target
+backend: bigquery | spanner             # required
+# BigQuery-specific:
+project: <string>                       # required for bigquery
+dataset: <string>                       # required for bigquery
+# Spanner-specific:
+instance: <string>                      # required for spanner
+database: <string>                      # required for spanner
+```
+
+```yaml
+# EntityBinding
+name: <string>                          # required, names an entity in the ontology
+source: <string>                        # required
+properties: [<PropertyBinding>, ...]    # required
+```
+
+```yaml
+# RelationshipBinding
+name: <string>                          # required, names a relationship in the ontology
+source: <string>                        # required
+from_columns: [<string>, ...]           # required, non-empty, arity matches from-entity primary key
+to_columns: [<string>, ...]             # required, non-empty, arity matches to-entity primary key
+properties: [<PropertyBinding>, ...]    # optional
+```
+
+```yaml
+# PropertyBinding
+name: <string>                          # required, names a property declared on the entity/relationship
+column: <string>                        # required
+```
+
+## 3. Target
+
+BigQuery:
+
+```yaml
+target:
+  backend: bigquery
+  project: my-proj
+  dataset: finance
+```
+
+Spanner:
+
+```yaml
+target:
+  backend: spanner
+  instance: my-instance
+  database: finance
+```
+
+Source names in entity and relationship bindings resolve relative to the
+target: for BigQuery, a bare `table` or `dataset.table` uses the target's
+`project` / `dataset` as defaults; a fully-qualified
+`project.dataset.table` overrides them. For Spanner, a bare `table`
+resolves against the target database. Views are valid sources for both.
+
+## 4. Entity binding
+
+- `name` must name an entity declared in the ontology.
+- `source` is the physical table or view. For row filtering (e.g.
+  `type = 'customer'`), build a view in the warehouse and bind to it.
+- `properties` must list one `PropertyBinding` for every **non-derived**
+  ontology property on the entity, including those inherited from parents
+  (inheritance is flattened at binding time). Derived properties — those
+  with `expr:` in the ontology — **must not** appear; the compiler
+  substitutes their referenced property names with bound columns.
+- **Primary keys are implicit.** The ontology's `keys.primary` names
+  properties; those property bindings supply the physical columns.
+
+## 5. Relationship binding
+
+- `name` must name a relationship declared in the ontology.
+- `source` is the physical edge table or view.
+- `from_columns` and `to_columns` name the columns in `source` that hold
+  the source/target endpoint keys. Their arity must equal the endpoint
+  entity's `keys.primary` arity.
+- `properties` binds the relationship's own non-derived properties, same
+  rules as §4.
+
+How endpoint substitutability (e.g. `HOLDS.from = Account` with both
+`Account` and `SavingsAccount` bound) lowers to backend DDL — one edge
+table, many edge tables, label-referenced edges, or a union view — is a
+compilation concern, out of scope here.
+
+## 6. Derived properties
+
+Properties with `expr:` in the ontology are never listed in the binding.
+At DDL emission the compiler substitutes each referenced property name
+with its bound column. A reference to a property that is not bound in this
+environment is a compile-time error.
+
+## 7. Partial bindings
+
+A binding realizes a **subset** of the ontology. An entity or relationship
+may be:
+
+1. **Absent from the binding** — not realized in this target; no DDL emitted.
+2. **Listed with a `source`** — realized.
+
+A logical parent may remain unbound while concrete children are bound;
+queries against the parent's label resolve against the bound children via
+substitutability (lowering is the compilation layer's job).
+
+Constraint: if a relationship is bound, both endpoint entities must have
+at least one bound descendant (including themselves) in this binding —
+otherwise the edge has nothing to point at.
+
+## 8. Type compatibility with the target
+
+The ontology is backend-neutral; the binding enforces target compatibility.
+
+- **BigQuery** supports all 11 logical types in `ontology.md` §7.
+- **Spanner** does not support `time` or `datetime`. A binding that
+  exposes either on a Spanner target fails validation.
+
+No implicit coercion. If the physical column type does not match the
+logical property type, fix it upstream (a view, or land the data
+correctly).
+
+## 9. Validation rules
+
+1. `binding` and `ontology` are non-empty strings.
+2. The ontology named by `ontology:` exists and loads without errors.
+3. `target.backend` is supported; backend-specific required fields are
+   present.
+4. Every `EntityBinding.name` names an entity declared in the ontology.
+5. Every `RelationshipBinding.name` names a relationship declared in the
+   ontology.
+6. No duplicate entity or relationship names within the binding.
+7. For every bound entity, every non-derived property (including
+   inherited) has exactly one `PropertyBinding` with a non-empty `column`.
+8. No `PropertyBinding` names a derived property.
+9. No `PropertyBinding` names a property not declared on the entity or
+   relationship (after inheritance flattening).
+10. For every bound relationship: `from_columns` length equals the `from`
+    entity's `keys.primary` length; same for `to_columns` and `to`.
+11. For every bound relationship: the `from` and `to` entities each have
+    at least one bound descendant (including themselves).
+12. For the Spanner target, no bound property has logical type `time` or
+    `datetime`.
+13. Unknown YAML keys anywhere are a validation error (`extra="forbid"`).
+
+## 10. Relationship to ontology
+
+- Binding references ontology entities and relationships by name only; no
+  schema redeclaration.
+- The binding's `ontology: <name>` resolves, by default, to
+  `<name>.ontology.yaml` in the same directory. A CLI flag can override
+  the lookup path.
+
+## 11. Open questions
+
+- **Light casts in bindings.** Narrow `cast: <type>` field (→ `CAST(column
+  AS type)`) vs. forcing users to a view. Revisit after first real use.
+- **Strict vs. loose property coverage.** Currently strict: every
+  non-derived property must be bound if the entity is bound. Loosening
+  would allow exposing a subset. Wait for concrete demand.
+- **Sources as SQL subqueries.** R2RML allows arbitrary SQL as a logical
+  table. We disallow it here to keep transformation out of YAML.
+  Reconsider if the rule proves onerous.
+- **Multi-target-in-one-file.** Reconsider if users consistently ask for
+  it.
+
+## 12. Out of scope
+
+- **Compilation and DDL emission**, including lowering strategies for
+  inheritance substitutability (label-referenced edges, fan-out, union
+  views).
+- **Credentials** — authentication is out-of-band.
+- **Transformation logic** — no arbitrary `expr:` in bindings; use views or
+  dbt.
+- **Composition of bindings** — shared defaults, multi-file assembly.
+- **Measures** and **deployment** — separate docs.

--- a/docs/ontology/cli.md
+++ b/docs/ontology/cli.md
@@ -1,0 +1,200 @@
+# Command Line Interface — Core Design (v0)
+
+Status: draft
+Scope: the v0 CLI for the `gm` tool. Three commands (`validate`,
+`compile`, `import-owl`) plus global conventions for output, errors, and
+exit codes. Out-of-scope items enumerated in §8.
+
+## 1. Goals
+
+- **Minimal surface.** Three commands cover both user workflows end to
+  end. Nothing else ships in v0.
+- **Composable.** Output is just text, stdout is where results go, exit
+  codes are honest. `gm compile … | bq query` works; CI parses errors
+  with `--json`.
+- **Predictable.** Same inputs → same output. Validation is strict and
+  runs implicitly before compilation.
+
+## 2. Workflows
+
+Two starting conditions cover the common cases.
+
+### Condition A: No existing tables (greenfield)
+
+| Step | Action | Command |
+|---|---|---|
+| 1 | Get an ontology: hand-author `finance.ontology.yaml`, or import from OWL | `gm import-owl fibo.ttl --include-namespace <…> -o finance.ontology.yaml` |
+| 2 | Resolve `FILL_IN` placeholders if any | — (text editor) |
+| 3 | Check the ontology is valid | `gm validate finance.ontology.yaml` |
+| 4 | Design and create warehouse tables | — (external) |
+| 5 | Author `finance-bq-prod.binding.yaml` | — (text editor) |
+| 6 | Check the binding | `gm validate finance-bq-prod.binding.yaml` |
+| 7 | Compile to DDL | `gm compile finance-bq-prod.binding.yaml` |
+| 8 | Apply DDL | — (external) |
+
+### Condition B: Existing tables (brownfield)
+
+| Step | Action | Command |
+|---|---|---|
+| 1 | Inspect existing table schemas | — (external) |
+| 2 | Author `finance.ontology.yaml` to describe the tables | — (text editor) |
+| 3 | Check the ontology is valid | `gm validate finance.ontology.yaml` |
+| 4 | Author `finance-bq-prod.binding.yaml` | — (text editor) |
+| 5 | Check the binding | `gm validate finance-bq-prod.binding.yaml` |
+| 6 | Compile to DDL | `gm compile finance-bq-prod.binding.yaml` |
+| 7 | Apply DDL (property graph only; tables already exist) | — (external) |
+
+## 3. Global conventions
+
+### Invocation
+
+Installed binary `gm`. Subcommand style is flat verb-noun hyphenated
+(`gm import-owl`, not `gm import owl`).
+
+### Output destinations
+
+- **stdout** — the primary result: DDL text (`gm compile`), imported
+  YAML (`gm import-owl` without `-o`), nothing on success
+  (`gm validate`).
+- **stderr** — diagnostics, warnings, human-readable errors.
+- `-o <file>` / `--out <file>` — redirect stdout to a file. Where
+  applicable (`gm compile`, `gm import-owl`).
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success. No errors; warnings may have been printed. |
+| 1 | Validation or compilation error (user-fixable). |
+| 2 | Usage error (bad flag, missing file). |
+| 3 | Internal error (unexpected exception). |
+
+### Error format
+
+Default is human-readable, one line per error in the form:
+
+```
+<file>:<line>:<col>: <rule> — <message>
+```
+
+Example:
+
+```
+finance.ontology.yaml:47:5: ontology-r11 — Entity "Account" has no primary key
+```
+
+`--json` emits a JSON array of structured error objects with fields
+`file`, `line`, `col`, `rule`, `severity` (`error` | `warning`),
+`message`. Warnings do not affect the exit code.
+
+### File conventions
+
+- **Suggested suffixes.** `*.ontology.yaml`, `*.binding.yaml`. The
+  loader detects file kind by the top-level key (`ontology:` or
+  `binding:`), so any extension is accepted.
+- **OWL source.** File extension selects the parser: `.ttl` (Turtle),
+  `.owl` / `.rdf` (RDF/XML).
+
+## 4. `gm validate`
+
+Check that a single YAML file conforms to its spec and cross-references
+resolve.
+
+### Usage
+
+```
+gm validate <file>
+```
+
+- Loader detects ontology vs binding from the top-level key.
+- **Ontology** → checked against `ontology.md` §10.
+- **Binding** → checked against `binding.md` §9. The loader also
+  attempts to locate the companion ontology (named by `ontology:` in
+  the binding, looked up as `<name>.ontology.yaml` in the same
+  directory) for cross-validation. If not found, binding validates
+  syntactically and the loader emits a warning.
+
+### Flags
+
+| Flag | Purpose |
+|---|---|
+| `--json` | Structured error output (see §3). |
+
+On success, nothing is written to stdout.
+
+## 5. `gm compile`
+
+Emit DDL from a binding. The companion ontology is located by the same
+rule as `gm validate` (§4).
+
+### Usage
+
+```
+gm compile <binding> [-o <out>]
+```
+
+- Runs validation implicitly on both files before emission. Any error
+  fails the compile; no partial DDL is emitted.
+- Writes DDL to stdout unless `-o` is given.
+
+### Flags
+
+| Flag | Purpose |
+|---|---|
+| `-o <file>`, `--out <file>` | Write DDL to file instead of stdout. |
+| `--json` | Structured errors for the implicit validation step. |
+
+On any validation or compilation error, no DDL is emitted — even partially.
+
+## 6. `gm import-owl`
+
+Read OWL sources and emit a `*.ontology.yaml` (see `owl-import.md`).
+
+### Usage
+
+```
+gm import-owl <source>... --include-namespace <iri>... [-o <out>]
+```
+
+- One or more OWL source files (Turtle, RDF/XML).
+- At least one `--include-namespace` required; multiple allowed.
+- Output uses `FILL_IN` for ambiguities and annotations for dropped OWL
+  features (see `owl-import.md` §11, §13). `FILL_IN` causes
+  `gm validate` to fail until resolved.
+
+### Flags
+
+| Flag | Purpose |
+|---|---|
+| `--include-namespace <iri>` | Required, repeatable. |
+| `-o <file>`, `--out <file>` | Write YAML to file instead of stdout. |
+| `--format ttl\|rdfxml` | Override parser selection from file extension. |
+| `--json` | Structured drop-and-placeholder summary. |
+
+Drop summary is printed to stderr regardless of `--json`.
+
+## 7. Open questions
+
+- **Warnings as errors.** A `--strict` flag that turns warnings into
+  exit-1 errors is common in similar tools. Defer until CI users ask.
+- **Log verbosity.** No `--verbose` / `-v` in v0. Validation and
+  compile output are already structured enough; add only if
+  debugging demands it.
+- **Config file.** A `gm.toml` or similar for per-project defaults
+  (namespace filters, target dataset) would simplify repeated
+  invocations. Defer until a concrete need surfaces.
+
+## 8. Out of scope
+
+- **`gm init`** — scaffold a minimal project. Users can copy from
+  `docs/distillation/examples/` once that exists.
+- **`gm inspect-schema`** — reverse-engineer a skeleton ontology from
+  an existing warehouse dataset. Useful for Workflow B but a
+  significant amount of backend-specific code.
+- **`gm deploy`** — apply DDL to a live backend. Explicitly off-limits
+  per `compilation.md` §1.
+- **`gm diff`** — compare two compilations. Text diff of DDL output
+  covers the need.
+- **Shell completion** — post-v0.
+- **Installation and packaging** — separate concern (PyPI, homebrew,
+  etc.).

--- a/docs/ontology/compilation.md
+++ b/docs/ontology/compilation.md
@@ -1,0 +1,251 @@
+# Compilation — Core Design (v0)
+
+Status: draft
+Scope: how an ontology (`ontology.md`) plus a binding (`binding.md`) are
+resolved and emitted as backend DDL (`CREATE PROPERTY GRAPH` on BigQuery or
+Spanner).
+
+**v0 compiles flat ontologies only.** Ontologies that use `extends` on
+entities or relationships are rejected at compile time. Inheritance
+lowering — substitutability, per-label property projections, cross-table
+identity, overlapping siblings — is the subject of a separate future
+design. Deployment, credentials, and measures are out of scope.
+
+## 1. Goals
+
+- **Single-shot compile.** Ontology plus binding in, DDL text out. No
+  intermediate on-disk artifact.
+- **Deterministic output.** Same inputs → byte-identical DDL.
+- **Backend-neutral pipeline, backend-specific emitter.** Resolution is
+  shared across backends; emission is per-backend.
+- **Output is just text.** What consumes it (deploy tool, `bq query`,
+  Terraform, a human) is outside this spec.
+
+## 2. Pipeline
+
+```
+ontology.yaml   ──┐
+                  ├──► Resolver ──► ResolvedGraph ──► Emitter ──► DDL
+binding.yaml    ──┘                                    (BQ|Spanner)
+```
+
+Stages:
+
+1. **Load.** Parse and validate ontology and binding independently against
+   their specs.
+2. **Resolve.** Cross-check names, wire derived expressions to bound
+   columns. Produce an in-memory `ResolvedGraph`.
+3. **Emit.** Walk the `ResolvedGraph` and produce backend-specific DDL.
+
+## 2a. Type overview (resolved model)
+
+```yaml
+# ResolvedGraph
+name: <string>                    # graph name, from ontology
+target: <Target>                  # from binding
+node_tables: [<NodeTable>, ...]
+edge_tables: [<EdgeTable>, ...]
+```
+
+```yaml
+# NodeTable
+label: <string>                   # entity name
+key_columns: [<string>, ...]
+source: <string>                  # fully qualified
+properties: [<ResolvedProperty>, ...]
+```
+
+```yaml
+# EdgeTable
+label: <string>                   # relationship name
+source: <string>
+from_key_columns: [<string>, ...]
+to_key_columns: [<string>, ...]
+from_node_table: <string>         # which node table this edge's source points to
+to_node_table: <string>
+properties: [<ResolvedProperty>, ...]
+```
+
+```yaml
+# ResolvedProperty
+name: <string>                    # logical property name
+type: <string>                    # GoogleSQL type
+sql: <string>                     # column name, or substituted expression for derived
+```
+
+## 3. Resolution
+
+### Substitute derived expressions
+
+For each derived property, substitute each name referenced in `expr:` with
+the column name from the binding. References to other derived properties
+are resolved recursively; cycles are a compile-time error.
+
+### Resolve endpoints
+
+For each relationship, look up the single node table for each endpoint
+entity. Because v0 does not lower inheritance, each endpoint entity is
+bound to exactly one node table, so endpoint resolution is direct.
+
+## 4. Emission
+
+Both backends produce `CREATE PROPERTY GRAPH` statements. Node tables and
+edge tables are listed in deterministic alphabetical order. Property lists
+follow the ontology declaration order of the owning entity / relationship.
+
+### BigQuery
+
+#### Worked example
+
+Ontology fragment:
+
+```yaml
+entities:
+  - name: Person
+    keys: { primary: [person_id] }
+    properties:
+      - { name: person_id,  type: string }
+      - { name: name,       type: string }
+      - { name: first_name, type: string }
+      - { name: last_name,  type: string }
+      - { name: full_name,  type: string,
+          expr: "first_name || ' ' || last_name" }
+  - name: Account
+    keys: { primary: [account_id] }
+    properties:
+      - { name: account_id, type: string }
+      - { name: opened_at,  type: timestamp }
+```
+
+Binding fragment:
+
+```yaml
+entities:
+  - name: Person
+    source: raw.persons
+    properties:
+      - { name: person_id,  column: person_id }
+      - { name: name,       column: display_name }
+      - { name: first_name, column: given_name }
+      - { name: last_name,  column: family_name }
+  - name: Account
+    source: raw.accounts
+    properties:
+      - { name: account_id, column: acct_id }
+      - { name: opened_at,  column: created_ts }
+```
+
+Emitted DDL:
+
+```sql
+CREATE PROPERTY GRAPH finance
+  NODE TABLES (
+    raw.accounts AS accounts
+      KEY (acct_id)
+      LABEL Account PROPERTIES (acct_id AS account_id, created_ts AS opened_at),
+    raw.persons AS persons
+      KEY (person_id)
+      LABEL Person PROPERTIES (
+        person_id,
+        display_name AS name,
+        given_name AS first_name,
+        family_name AS last_name,
+        (given_name || ' ' || family_name) AS full_name
+      )
+  )
+  EDGE TABLES (
+    raw.holdings AS holdings
+      SOURCE KEY (account_id) REFERENCES accounts (acct_id)
+      DESTINATION KEY (security_id) REFERENCES securities (cusip)
+      LABEL HOLDS PROPERTIES (snapshot_date AS as_of, qty AS quantity)
+  );
+```
+
+Derived expressions become SQL expressions in the `PROPERTIES` list;
+column renames become `AS` clauses.
+
+### Spanner
+
+Same `CREATE PROPERTY GRAPH` / `NODE TABLES` / `EDGE TABLES` form, minor
+syntactic differences.
+
+### Relationship to the GCP reference grammar
+
+The resolved model maps to the `CREATE PROPERTY GRAPH` grammar as follows:
+
+| Resolved model | GCP grammar |
+|---|---|
+| `NodeTable.source` | `<source> [AS <alias>]` |
+| `NodeTable.key_columns` | `KEY (<cols>)` |
+| `NodeTable.label` + `properties` | `LABEL <name> PROPERTIES (<spec_list>)` |
+| `EdgeTable.from_key_columns` + `from_node_table` | `SOURCE KEY (<cols>) REFERENCES <node>` |
+| `EdgeTable.to_key_columns` + `to_node_table` | `DESTINATION KEY (<cols>) REFERENCES <node>` |
+
+The resolved model collapses the grammar's variant forms to a single
+canonical shape. We always emit the explicit
+`LABEL <name> PROPERTIES (<list>)` form and do not emit:
+
+- `DEFAULT LABEL` — our properties are always enumerated.
+- `PROPERTIES ARE ALL COLUMNS` — same reason.
+- `LABEL <name> NO PROPERTIES` — every label projects at least one
+  property.
+- `DYNAMIC LABEL` / `DYNAMIC PROPERTIES` — our ontology is closed-world
+  with declared labels and properties. See §7.
+
+References:
+[Spanner graph schema statements](https://cloud.google.com/spanner/docs/reference/standard-sql/graph-schema-statements),
+[BigQuery graph creation](https://cloud.google.com/bigquery/docs/graph-create).
+
+## 5. Derived expressions in DDL
+
+Derived properties appear as `<substituted_expr> AS <name>` in the
+`PROPERTIES` list. No intermediate view is created. See the `full_name`
+example in §4.
+
+## 6. Compile-time validation
+
+On top of ontology-level (`ontology.md` §10) and binding-level
+(`binding.md` §9) rules:
+
+1. **No `extends`.** No entity or relationship in the ontology uses
+   `extends`. Compilation of hierarchical ontologies is reserved for a
+   future design.
+2. Every name in a derived expression resolves to a bound or derived
+   property on the same entity or relationship.
+3. No cycles among derived properties.
+4. Every logical property type is supported by the target backend
+   (`ontology.md` §7).
+
+Warnings: bound entity referenced by no relationship.
+
+## 7. Determinism and output shape
+
+One `CREATE PROPERTY GRAPH` per compile. Node tables sorted alphabetically,
+then edge tables sorted alphabetically. Property lists follow ontology
+declaration order.
+
+## 8. Open questions
+
+- **Multi-graph output.** One `CREATE PROPERTY GRAPH` per compile.
+  Multi-graph from one ontology is a composition concern.
+- **`DYNAMIC LABEL`.** Spanner and BigQuery support a string column as a
+  runtime-assigned label (one node table and one edge table per schema).
+  We don't emit it today — closed-world ontology with declared labels is
+  enough. Revisit if an importer or user surfaces a real need.
+
+## 9. Out of scope
+
+- **Inheritance lowering.** Compilation of ontologies with `extends` —
+  substitutability, per-label property projections, fanout vs union-view
+  vs label-ref strategies, cross-table identity, overlapping siblings,
+  merged-node lowering. Separate future design.
+- **CLI surface.** Command names, flag names, output destinations — a
+  separate doc.
+- **Applying DDL to a live backend.** Credentials, transactions, rollback,
+  drift detection. Any tool that can accept DDL text can consume this
+  compiler's output.
+- **Measures and aggregations.** Not part of the property graph DDL.
+- **Composition.** Multi-file ontology assembly, shared binding defaults,
+  overlay graphs.
+- **Schema evolution and migration.** Diffing two compiled outputs and
+  emitting `ALTER` statements — separate concern.

--- a/docs/ontology/ontology.md
+++ b/docs/ontology/ontology.md
@@ -1,0 +1,385 @@
+# Ontology — Core Design (v0)
+
+Status: draft
+Scope: the logical ontology spec only. Bindings, compilation, deployment,
+measures, and multi-file composition are deliberately out of scope for this
+document and will each have their own design.
+
+## 1. Goals
+
+- A **logical ontology** in YAML, independent of any physical warehouse.
+- One file, no composition.
+- Separate logical modeling (this doc) from physical binding (separate doc).
+
+## 2. File shape
+
+One file per ontology. Suffix: `*.ontology.yaml`. Top-level key: `ontology:`.
+
+All YAML in this document uses **block style** (indented, one field per line)
+for consistency. YAML's flow style (`{a: 1, b: 2}` for maps, `[x, y]` for
+lists) is equivalent and users may use it freely; the two styles parse to
+identical data. Block style is used here to give the spec a single canonical
+reading.
+
+```yaml
+ontology: finance
+version: 0.1
+
+entities:
+  - name: Party
+    keys:
+      primary:
+        - party_id
+    properties:
+      - name: party_id
+        type: string
+      - name: name
+        type: string
+
+  - name: Person
+    extends: Party
+    properties:
+      - name: dob
+        type: date
+      - name: first_name
+        type: string
+      - name: last_name
+        type: string
+      - name: full_name
+        type: string
+        expr: "first_name || ' ' || last_name"
+
+  - name: Organization
+    extends: Party
+    properties:
+      - name: tax_id
+        type: string
+
+  - name: Account
+    keys:
+      primary:
+        - account_id
+    properties:
+      - name: account_id
+        type: string
+      - name: opened_at
+        type: timestamp
+
+  - name: Security
+    keys:
+      primary:
+        - security_id
+    properties:
+      - name: security_id
+        type: string
+
+relationships:
+  - name: HOLDS
+    keys:
+      additional:
+        - as_of
+    from: Account
+    to: Security
+    cardinality: many_to_many
+    properties:
+      - name: as_of
+        type: timestamp
+      - name: quantity
+        type: double
+
+  - name: TRANSFER
+    keys:
+      primary:
+        - transaction_id
+    from: Account
+    to: Account
+    properties:
+      - name: transaction_id
+        type: string
+      - name: amount
+        type: double
+      - name: executed_at
+        type: timestamp
+
+  - name: RELATED_TO
+    from: Party
+    to: Party
+
+description: Party, account, and security model for finance domain.
+synonyms:
+  - finance-core
+```
+
+## 2a. Type overview
+
+Compact YAML signatures. `<T>` is a placeholder; `, ...` means "list of".
+
+```yaml
+# Ontology  (top-level)
+ontology: <string>                      # required
+version: <string>                       # optional
+entities: [<Entity>, ...]               # required, non-empty
+relationships: [<Relationship>, ...]    # optional
+description: <string>                   # optional
+synonyms: [<string>, ...]               # optional
+annotations: {<string>: <string> | [<string>, ...]}       # optional
+```
+
+```yaml
+# Entity
+name: <string>                          # required, unique in ontology
+extends: <string>                       # optional, name of parent entity
+keys: <Keys>                            # required
+properties: [<Property>, ...]           # optional
+description: <string>                   # optional
+synonyms: [<string>, ...]               # optional
+annotations: {<string>: <string> | [<string>, ...]}       # optional
+```
+
+```yaml
+# Relationship
+name: <string>                          # required, unique in ontology
+extends: <string>                       # optional, name of parent relationship
+keys: <Keys>                            # optional
+from: <string>                          # required, entity name
+to: <string>                            # required, entity name
+cardinality: one_to_one | one_to_many | many_to_one | many_to_many  # optional
+properties: [<Property>, ...]           # optional
+description: <string>                   # optional
+synonyms: [<string>, ...]               # optional
+annotations: {<string>: <string> | [<string>, ...]}       # optional
+```
+
+```yaml
+# Property
+name: <string>                          # required, unique within parent
+type: string | bytes | integer | double | numeric | boolean | date | time | datetime | timestamp | json  # required
+expr: <string>                          # optional, BigQuery SQL over sibling properties
+description: <string>                   # optional
+synonyms: [<string>, ...]               # optional
+annotations: {<string>: <string> | [<string>, ...]}       # optional
+```
+
+```yaml
+# Keys
+primary: [<string>, ...]                # required on entities; one of primary/additional on relationships
+alternate:                              # optional; only valid with primary
+  - [<string>, ...]
+additional: [<string>, ...]             # relationships only, mode 2: extends (from, to)
+```
+
+## 3. Entity
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `name` | string | yes | Unique within the ontology. |
+| `extends` | string | no | Name of the parent entity. Single-parent. |
+| `keys` | Keys | yes | See §6. |
+| `properties` | list\<Property\> | no | See §5. |
+| `description` | string | no | Free-form. |
+| `synonyms` | list\<string\> | no | Alternate names for search / LLM grounding. |
+| `annotations` | map\<string, string \| list\<string\>\> | no | Free-form metadata. Values may be a string or a list of strings. |
+
+## 4. Relationship
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `name` | string | yes | Unique within the ontology. |
+| `extends` | string | no | Name of the parent relationship. Single-parent. |
+| `keys` | Keys | no | See §6. |
+| `from` | string | yes | Source entity name. |
+| `to` | string | yes | Target entity name. |
+| `cardinality` | enum | no | `one_to_one` \| `one_to_many` \| `many_to_one` \| `many_to_many`. |
+| `properties` | list\<Property\> | no | See §5. |
+| `description` | string | no | |
+| `synonyms` | list\<string\> | no | |
+| `annotations` | map\<string, string \| list\<string\>\> | no | |
+
+## 5. Property
+
+A property is an attribute of an entity or relationship.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `name` | string | yes | Unique within its containing entity or relationship. |
+| `type` | enum | yes | See §7. |
+| `expr` | string | no | BigQuery SQL expression over other properties of the same entity/relationship. See §8. |
+| `description` | string | no | |
+| `synonyms` | list\<string\> | no | |
+| `annotations` | map\<string, string \| list\<string\>\> | no | |
+
+Properties with `expr` are *derived* — their value is computed from other
+properties.
+
+## 6. Keys
+
+A single `Keys` shape is used on both entities and relationships. Some
+fields are valid only in one context.
+
+```yaml
+# Keys
+primary: [<string>, ...]                # required on entities; one of primary/additional on relationships
+alternate:                              # optional; only valid with primary
+  - [<string>, ...]
+additional: [<string>, ...]             # relationships only
+```
+
+### Rules
+
+- Every name in any list must be a property declared on the same entity
+  or relationship.
+- `alternate` keys are each non-empty; no duplicates within or across
+  primary/alternate.
+- **On entities**: `primary` is required; `additional` is not allowed.
+- **On relationships**: `primary` XOR `additional` (neither is also
+  allowed, meaning no uniqueness constraint — multi-edges permitted).
+  `alternate` only applies with `primary`.
+
+### Relationship key modes
+
+- **Mode 1 — standalone primary key.** The edge has its own identity;
+  endpoints are foreign keys, not part of the key.
+
+  ```yaml
+  keys:
+    primary: [transaction_id]
+    alternate:
+      - [external_ref, source_system]
+  ```
+
+- **Mode 2 — endpoint-extended key.** The edge's effective key is
+  `(from, to, *additional)`.
+
+  ```yaml
+  keys:
+    additional: [as_of]
+  ```
+
+If a relationship's identity is rich (its own synthetic ID plus outgoing
+edges), model it as an entity with two relationships to its endpoints.
+
+## 7. Valid property types
+
+The ontology uses semantic type names that map to the GoogleSQL type system
+shared by BigQuery and Spanner.
+
+```
+string, bytes, integer, double, numeric,
+boolean, date, time, datetime, timestamp, json
+```
+
+Any other value is a validation error.
+
+### Backend mapping
+
+| Ontology type | BigQuery | Spanner |
+|---|---|---|
+| `string` | `STRING` | `STRING` |
+| `bytes` | `BYTES` | `BYTES` |
+| `integer` | `INT64` | `INT64` |
+| `double` | `FLOAT64` | `FLOAT64` |
+| `numeric` | `NUMERIC` | `NUMERIC` |
+| `boolean` | `BOOL` | `BOOL` |
+| `date` | `DATE` | `DATE` |
+| `time` | `TIME` | — |
+| `datetime` | `DATETIME` | — |
+| `timestamp` | `TIMESTAMP` | `TIMESTAMP` |
+| `json` | `JSON` | `JSON` |
+
+Backend-unsupported combinations (e.g., `time` on a Spanner target) are
+binding/compile-time errors, not ontology-level errors. The ontology stays
+backend-neutral.
+
+### Deliberately deferred
+
+- `bignumeric` (BQ only, higher-precision decimal).
+- `interval` (portability questions between BQ and Spanner semantics).
+- `geography` (BQ only; representation questions).
+- Composite types `array<T>` and `struct<...>`: model nested data as separate
+  entities plus relationships for v0.
+- Parameterized types (e.g., `numeric(38, 9)`, `string(100)`): GoogleSQL
+  accepts precision/scale and length, but v0 ignores them.
+
+## 8. Expression dialect
+
+Property `expr` uses **BigQuery Standard SQL** syntax. The expression may
+reference other properties declared on the same entity or relationship by name;
+it may not reference other entities, relationships, or host columns.
+
+Example:
+```yaml
+- name: full_name
+  type: string
+  expr: "first_name || ' ' || last_name"
+```
+
+No subqueries, window functions, or aggregates.
+
+## 9. Inheritance
+
+Inheritance applies uniformly to entities and relationships.
+
+| Aspect | Entity | Relationship |
+|---|---|---|
+| `extends` form | single parent | single parent |
+| Multi-inheritance | not supported | not supported |
+| Cycles | validation error | validation error |
+| Properties | inherited and merged; child adds, redeclaration is an error | same |
+| Keys | inherited; child cannot redeclare | same |
+| Endpoints | — | covariant narrowing: child `from` must equal or extend parent `from`; same for `to` |
+| Cardinality | — | inherited unchanged (narrowing deferred) |
+| `description`, `synonyms`, `annotations` | not inherited | not inherited |
+| Substitutability in queries | `MATCH (:Parent)` matches all descendants | `MATCH -[:parent]-` matches all descendant edges |
+
+Covariant-narrowing example: parent `memberOf: Party → Organization`;
+child `alumni: Person → School` is valid iff `Person extends Party` and
+`School extends Organization`.
+
+## 10. Validation rules
+
+Enforced by the ontology loader before any downstream stage runs.
+
+1. Every entity and relationship name is unique within the ontology.
+2. Every property name is unique within its entity or relationship.
+3. `extends` must resolve to a declared entity (entity-to-entity) or
+   relationship (relationship-to-relationship) of the correct kind.
+4. No cycles in `extends` chains.
+5. Redeclaring an inherited property (by name) is an error.
+6. Redeclaring inherited keys is an error.
+7. Every name in any `keys` list must be a property declared on the same
+   entity or relationship.
+8. Alternate keys are non-empty and have no duplicates within or across
+   primary/alternate.
+9. On relationships, `primary` and `additional` are mutually exclusive.
+   On entities, `additional` is not allowed.
+10. Relationships with `extends`: `from` / `to` satisfy covariant narrowing
+    against the parent's endpoints.
+11. Every entity must declare `keys.primary`.
+12. Property `type` is one of the valid types (§7).
+13. Unknown YAML keys anywhere in the spec are an error (`extra="forbid"`).
+
+## 11. Out of scope / future docs
+
+- **Binding** — mapping logical entities and relationships to physical tables
+  and columns, per backend/environment.
+- **Compilation** — resolving ontology + binding into emitted DDL, including
+  lowering strategies for inheritance substitutability.
+- **Measures** — aggregations over entity/relationship properties, reintroduced
+  as a separate overlay on top of the ontology.
+- **Composition** — includes, excludes, multi-file assembly, multi-domain
+  directory layouts, `GraphSpec`-style selectors.
+
+## 12. Open questions
+
+- **Reintroduce `abstract`?** Dropped from v0 because it leaks binding-layer
+  semantics into the ontology — an unbound entity in a given environment is
+  effectively abstract for that environment, and the binding layer can warn
+  on "unbound entity with no bound descendants." Revisit if that check proves
+  insufficient in practice.
+- **Cardinality narrowing under inheritance.** Currently specified as
+  "inherited unchanged." Narrowing (e.g., parent `many_to_many`, child
+  `one_to_many`) has obvious modeling value but raises enforcement questions;
+  revisit after the binding/compilation design lands.
+- **Expression dialect scope.** BigQuery Standard SQL is pragmatic but ties
+  the ontology to a specific backend's syntax. Worth revisiting if a second
+  backend (Spanner) surfaces real incompatibilities.

--- a/docs/ontology/owl-import.md
+++ b/docs/ontology/owl-import.md
@@ -1,0 +1,491 @@
+# OWL Import — Core Design (v0)
+
+Status: draft
+Scope: converting OWL source ontologies into our `*.ontology.yaml` format
+(see `ontology.md`). The importer produces ontology files; bindings are
+user-authored separately.
+
+## 1. Goals
+
+- **Faithful.** Preserve as much of the source OWL structure as fits our
+  model. Do not silently lose subclass relationships or property
+  declarations.
+- **No silent drops.** OWL features we cannot map (restrictions,
+  equivalence axioms, property characteristics, etc.) are recorded on
+  the affected entity or relationship. Simple scalar drops go into
+  `annotations` (machine-readable); structured drops that don't fit a
+  string value go into YAML comments. The importer also prints a
+  summary.
+- **Deterministic.** Same input → byte-identical output.
+- **User-resolvable ambiguities.** When OWL expresses something our model
+  does not (multi-parent subclasses, multi-range properties, missing
+  keys), emit a placeholder with an inline comment in the output file
+  for the user to resolve rather than silently pick.
+- **Output validates.** The emitted ontology.yaml must pass `ontology.md`
+  validation. Placeholders that require user input cause a clear,
+  actionable validation failure.
+
+## 2. Pipeline
+
+```
+OWL file(s)  ──► Parser ──► Triples ──► Filter ──► Mapper ──► ontology.yaml
+                                          ▲
+                                          │
+                                    namespaces
+```
+
+Stages:
+
+1. **Parse.** Read OWL source (Turtle or RDF/XML) into an RDF triple store.
+2. **Filter.** Keep only triples whose subject IRI matches a user-provided
+   namespace list. Follow `owl:imports` to fetch dependencies, but still
+   filter by namespace.
+3. **Map.** Apply the §5 mapping table to produce entities, relationships,
+   and properties. When the source is ambiguous or under-specified, emit
+   a placeholder sentinel with an inline YAML comment; see §11.
+4. **Emit.** Write ontology.yaml in canonical order (§14).
+
+Resolution happens **in the output file** by the user editing
+placeholders — there is no separate hints file.
+
+## 3. Input formats
+
+- **Turtle** (`.ttl`) — primary.
+- **RDF/XML** (`.owl`, `.rdf`) — supported; most ontologies ship at least
+  one RDF/XML serialization.
+
+Both parse to the same triple store; everything downstream is
+format-agnostic. JSON-LD, N3, and N-Triples are deferred until demand
+appears.
+
+## 4. Namespace filtering
+
+The importer requires at least one namespace IRI prefix. Only RDF
+resources whose IRIs start with an included prefix are mapped into the
+output ontology. Everything else — including classes and properties
+reached via `owl:imports` — is excluded.
+
+Example: given `--include-namespace https://spec.edmcouncil.org/fibo/ontology/FBC/`,
+a FIBO source file imports hundreds of vocabularies; only FBC-namespace
+classes and properties are mapped.
+
+Multiple namespaces may be included. No wildcard matching in v0.
+
+### Exclusions are reported, not silent
+
+Namespace filtering is an explicit user choice, but its consequences are
+still surfaced:
+
+- **Importer output summary** lists counts of classes and properties
+  excluded per namespace. This lets users verify the filter matches
+  intent (e.g., catch typos in namespace IRIs).
+- **Cross-boundary references from kept entities** are recorded on the
+  kept entity. If kept `Person` has `rdfs:subClassOf :upper#Agent`
+  where `:upper#` is outside the filter, the `extends` field is not
+  set, and an annotation records the severed link:
+
+  ```yaml
+  - name: Person
+    description: Person
+    annotations:
+      owl:subClassOf_excluded: https://example.com/upper#Agent
+  ```
+
+  Similarly for property domains/ranges that point outside the
+  filter (`owl:domain_excluded`, `owl:range_excluded`).
+
+The rule is the same as §13: simple scalar drops become annotations,
+structured drops become comments. Filtering is just a different reason
+for dropping.
+
+## 5. Mapping table
+
+| OWL construct | Our ontology (`ontology.md`) |
+|---|---|
+| `owl:Class` | Entity |
+| `owl:DatatypeProperty` with `rdfs:domain C`, `rdfs:range xsd:T` | Property on entity `C` with `type: T` |
+| `owl:ObjectProperty` with `rdfs:domain A`, `rdfs:range B` | Relationship `from: A, to: B` |
+| `rdfs:subClassOf` (single parent) | `extends` on entity |
+| `rdfs:subPropertyOf` (single parent) | `extends` on relationship |
+| `owl:hasKey` | `keys.primary` |
+| `rdfs:label` | `description` (first) or appended to `synonyms` |
+| `rdfs:comment` | `description` (if no label, or appended) |
+| `skos:altLabel`, `skos:prefLabel` | `synonyms` |
+| `owl:FunctionalProperty` | Relationship `cardinality: many_to_one` (object prop); ignored for datatype prop |
+
+Everything else is dropped; see §13.
+
+## 6. Type mapping
+
+XSD datatypes → our 11 types (`ontology.md` §7):
+
+| XSD | Ontology |
+|---|---|
+| `xsd:string`, `xsd:normalizedString`, `xsd:token` | `string` |
+| `xsd:hexBinary`, `xsd:base64Binary` | `bytes` |
+| `xsd:integer`, `xsd:int`, `xsd:long`, `xsd:short`, `xsd:byte`, `xsd:unsignedInt`, `xsd:unsignedLong`, `xsd:unsignedShort`, `xsd:nonNegativeInteger`, `xsd:positiveInteger`, `xsd:nonPositiveInteger`, `xsd:negativeInteger` | `integer` |
+| `xsd:double`, `xsd:float` | `double` |
+| `xsd:decimal` | `numeric` |
+| `xsd:boolean` | `boolean` |
+| `xsd:date` | `date` |
+| `xsd:time` | `time` |
+| `xsd:dateTime`, `xsd:dateTimeStamp` | `timestamp` |
+| `rdf:JSON` | `json` |
+| `xsd:anyURI` | `string` (with annotation `xsd_type: anyURI`) |
+
+Unknown or unmapped XSD types produce a warning and default to `string`.
+
+## 7. Inheritance
+
+- **Single `rdfs:subClassOf` parent** → `extends` on the entity. Direct.
+- **Multiple `rdfs:subClassOf` parents** → emit `extends: FILL_IN` plus
+  a YAML comment listing the candidates. User edits to pick one.
+- **Single `rdfs:subPropertyOf` parent** → `extends` on the relationship.
+- **Multiple `rdfs:subPropertyOf` parents** → same as above.
+
+The importer preserves `extends` faithfully. The output ontology may use
+inheritance that the v0 compiler (see `compilation.md`) does not yet
+lower; that is a compiler concern, not an importer concern.
+
+## 8. Domain and range
+
+OWL allows a property to have multiple `rdfs:domain` or `rdfs:range`
+values, interpreted as "the intersection of these."
+
+- **Single domain and range** → direct mapping.
+- **Multiple domain or range** → emit `from: FILL_IN` or `to: FILL_IN`
+  (or `type: FILL_IN` for datatype properties) plus a YAML comment
+  listing the candidates. User edits to pick one.
+
+## 9. Annotations
+
+- `rdfs:label` (prefLabel, if multiple pick English first, else
+  alphabetically first) → `description`.
+- `rdfs:comment` → appended to `description` with a blank-line separator
+  when a label is also present.
+- `skos:altLabel` and additional `rdfs:label`s in other languages →
+  `synonyms`.
+- Custom annotation properties outside our recognized set → collected as
+  `annotations: { <iri>: <value> }` when the value is a literal; dropped
+  silently when not.
+
+## 10. Primary keys
+
+- **Class has `owl:hasKey`** → the listed properties become
+  `keys.primary` in declaration order.
+- **Class has no `owl:hasKey`** → the importer emits
+  `keys: { primary: [FILL_IN] }` as a placeholder, with a YAML comment
+  explaining. The output fails `ontology.md` validation rule 11 until
+  the user edits the placeholder.
+
+This placeholder is intentional: silently guessing a key is worse than
+making the user pick, because keys drive binding column mapping and
+substitutability.
+
+## 11. Placeholders and in-file resolution
+
+When the importer cannot produce a valid answer from the OWL source
+alone, it emits a `FILL_IN` sentinel value at the ambiguous site, plus a
+YAML comment explaining the decision. The user resolves each by editing
+the file directly.
+
+Three places placeholders appear:
+
+- **Missing primary key** (§10). Value: `FILL_IN`. Comment: source had
+  no `owl:hasKey`; list data properties on the class as hints.
+- **Multi-parent `extends`** (§7). Value: `FILL_IN`. Comment: lists all
+  declared parents.
+- **Multi-domain or multi-range property** (§8). Value: `FILL_IN`.
+  Comment: lists all declared candidates.
+
+Example emitted fragment:
+
+```yaml
+- name: Account
+  # no owl:hasKey in OWL source
+  # candidate data properties: account_id, external_ref
+  keys:
+    primary: [FILL_IN]
+
+- name: JointAccount
+  # multi-parent: rdfs:subClassOf [Account, Organization]
+  extends: FILL_IN
+```
+
+Rules:
+
+- `FILL_IN` is a reserved string. Any occurrence in the emitted output
+  fails `ontology.md` validation.
+- The importer never silently picks. If the source is ambiguous, a
+  placeholder is emitted.
+- Users resolve by replacing `FILL_IN` with a valid value. Comments can
+  be deleted or kept — the loader ignores YAML comments.
+
+## 12. Naming policy
+
+Local names in the emitted ontology are derived from the IRI:
+
+- If the IRI ends with `#<fragment>`, use the fragment.
+- Else use the last path segment.
+- Strip or rewrite characters not allowed in our names (deferred — see
+  §16).
+
+Name collisions across the included namespaces are an error. Users
+resolve by narrowing the namespace filter; an in-file override
+mechanism is a future concern (see §16).
+
+## 13. What gets dropped
+
+OWL features the importer cannot map to our model:
+
+- **Class expressions.** `owl:unionOf`, `owl:intersectionOf`,
+  `owl:complementOf`, `owl:oneOf`.
+- **Restrictions.** `owl:someValuesFrom`, `owl:allValuesFrom`,
+  `owl:minCardinality`, `owl:maxCardinality`,
+  `owl:qualifiedCardinality`, `owl:hasValue`.
+- **Equivalence and disjointness.** `owl:equivalentClass`,
+  `owl:equivalentProperty`, `owl:disjointWith`,
+  `owl:AllDisjointClasses`, `owl:sameAs`.
+- **Property characteristics** beyond `owl:FunctionalProperty`:
+  `owl:InverseFunctionalProperty`, `owl:TransitiveProperty`,
+  `owl:SymmetricProperty`, `owl:AsymmetricProperty`,
+  `owl:ReflexiveProperty`, `owl:IrreflexiveProperty`.
+- **`owl:inverseOf`.** See §16.
+- **Anonymous classes / blank nodes.**
+- **Individuals / ABox triples.**
+- **Punning** (same IRI as class and instance).
+
+### How drops are surfaced
+
+**Preferred: structured annotations.** Simple drops go into the
+entity or relationship's `annotations:` map, where they are
+machine-readable and can be round-tripped or queried. Values are
+strings for single OWL values, or lists of strings when an OWL property
+has multiple values (e.g., a class with two `owl:equivalentClass`
+targets):
+
+| Dropped OWL construct | Annotation key | Value |
+|---|---|---|
+| `owl:equivalentClass` | `owl:equivalentClass` | target name, or list |
+| `owl:equivalentProperty` | `owl:equivalentProperty` | target name, or list |
+| `owl:disjointWith` | `owl:disjointWith` | target name, or list |
+| `owl:sameAs` | `owl:sameAs` | target name, or list |
+| `owl:inverseOf` | `owl:inverseOf` | target name |
+| `owl:TransitiveProperty`, `owl:SymmetricProperty`, etc. | `owl:characteristics` | list of flags, e.g. `[Transitive, Symmetric]` |
+| `owl:InverseFunctionalProperty` | `owl:characteristics` | includes `InverseFunctional` |
+
+```yaml
+- name: Person
+  description: Person
+  extends: Party
+  annotations:
+    owl:disjointWith: [Organization, Trust]
+    owl:equivalentClass: NaturalPerson
+
+relationships:
+  - name: heldBy
+    from: Account
+    to: Party
+    annotations:
+      owl:inverseOf: holds
+      owl:characteristics: [Transitive]
+```
+
+Emit a scalar when the OWL source has exactly one value and a list when
+it has more than one. The loader accepts both (see `ontology.md` §3).
+
+**Fallback: YAML comments.** Drops that don't fit a string or list-of-
+strings value go into a comment above the entity or relationship:
+
+- **Restrictions** (`someValuesFrom`, `allValuesFrom`, `minCardinality`,
+  `maxCardinality`, `qualifiedCardinality`, `hasValue`).
+- **Class expressions** (`unionOf`, `intersectionOf`, `complementOf`,
+  `oneOf`).
+- **Anonymous classes / blank nodes** referenced from an otherwise
+  mapped class.
+
+```yaml
+- name: Person
+  # restriction on age: minInclusive 0, maxExclusive 150
+  # unionOf: Person, Organization, Trust
+  description: Person
+  ...
+```
+
+**Importer output summary.** Counts per drop category plus a pointer to
+each site. CI can check counts; users get a quick overview without
+opening the ontology.
+
+Drops not tied to a specific entity (individuals, punning, orphan
+blank nodes) appear only in the importer output summary.
+
+## 14. Determinism
+
+- Entities sorted alphabetically by local name.
+- Relationships sorted alphabetically by local name.
+- Properties within an entity or relationship sorted alphabetically.
+- Synonyms sorted alphabetically.
+
+## 15. Validation
+
+The importer validates its own output:
+
+1. Every entity has `keys.primary` (§10 placeholder fails this; user
+   must fix).
+2. No multi-parent `extends` unresolved (§7).
+3. No multi-domain or multi-range properties unresolved (§8).
+4. Name collisions resolved (§12).
+5. The produced file parses as a valid ontology per `ontology.md` §10.
+
+Failures block output; the importer prints a structured list of
+actionable issues.
+
+## 16. Open questions
+
+- **`owl:inverseOf`.** Should the importer synthesize a paired inverse
+  relationship (two relationships sharing a source edge, one forward, one
+  back)? Currently dropped. Revisit after first real-ontology use.
+- **Re-import workflow.** Re-running the importer overwrites user edits
+  (including `FILL_IN` resolutions). For v0 the flow is one-shot: import,
+  edit, commit. If OWL sources evolve and need re-importing, the user
+  re-imports into a fresh file and reconciles via git. A future
+  `--merge` mode could preserve user edits, but it is not in v0.
+- **Name overrides.** Handling very long or awkward local names
+  (CamelCase collisions, reserved keywords). Currently out of scope; an
+  inline override mechanism (e.g. a YAML annotation carrying the source
+  IRI) could be added later.
+- **Profile filtering.** Allow the user to restrict import to OWL EL,
+  QL, or RL subsets. Not in v0; most importers don't need it.
+- **Identifier escaping policy.** Characters in IRIs that aren't valid
+  in our `name` field (`.`, `-`, leading numerics). Current plan: fail
+  the import with a clear message pointing at the offending IRI.
+- **`owl:imports` fetch policy.** Follow remote imports over HTTP, or
+  only local filesystem? Network access raises reproducibility concerns.
+- **Annotation property preservation.** Currently kept as
+  `annotations: {iri: value}` for literal values; non-literal
+  annotations are dropped. Revisit if ontologies lean heavily on SKOS
+  hierarchies or Dublin Core metadata.
+
+## 17. Out of scope
+
+- **CLI surface.** Command name, flags, output path conventions — a
+  separate doc.
+- **Other importers.** Schema.org, FHIR, OpenAPI each get their own
+  design doc.
+- **Bindings.** The importer produces ontology only. Physical bindings
+  are authored separately by users familiar with the target backend.
+- **Export back to OWL.** Round-trip is not a goal; see
+  `relationship-to-standards.md` OWL section for the lossy gaps.
+- **Reasoning over imported ontologies.** We import structure, not
+  entailments.
+- **Diffing imports across source versions.** A separate concern.
+
+## 18. Worked example
+
+### OWL source (Turtle)
+
+```turtle
+@prefix : <https://example.com/finance#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:Party  a owl:Class ; rdfs:label "Party" ;
+    owl:hasKey ( :party_id ) .
+
+:Person  a owl:Class ;
+    rdfs:subClassOf :Party ;
+    rdfs:label "Person" ;
+    owl:disjointWith :Organization .
+
+:Organization  a owl:Class ;
+    rdfs:subClassOf :Party ;
+    rdfs:label "Organization" .
+
+:party_id  a owl:DatatypeProperty ;
+    rdfs:domain :Party ;
+    rdfs:range xsd:string .
+
+:name  a owl:DatatypeProperty ;
+    rdfs:domain :Party ;
+    rdfs:range xsd:string .
+
+:Account  a owl:Class ;
+    rdfs:label "Account" .
+
+:heldBy  a owl:ObjectProperty, owl:TransitiveProperty ;
+    owl:inverseOf :holds ;
+    rdfs:domain :Account ;
+    rdfs:range :Party .
+```
+
+### Emitted ontology.yaml (with placeholder and drop annotations)
+
+- `Account` has no `owl:hasKey` → `FILL_IN` placeholder (§10).
+- Person's `owl:disjointWith Organization` → `annotations`.
+- `heldBy`'s `owl:TransitiveProperty` → `annotations.owl:characteristics`.
+- `heldBy`'s `owl:inverseOf :holds` → `annotations.owl:inverseOf`.
+
+```yaml
+ontology: finance
+
+entities:
+  - name: Account
+    description: Account
+    # no owl:hasKey in OWL source — pick a primary-key property
+    keys:
+      primary: [FILL_IN]
+
+  - name: Organization
+    description: Organization
+    extends: Party
+
+  - name: Party
+    description: Party
+    keys:
+      primary: [party_id]
+    properties:
+      - name: name
+        type: string
+      - name: party_id
+        type: string
+
+  - name: Person
+    description: Person
+    extends: Party
+    annotations:
+      owl:disjointWith: Organization
+
+relationships:
+  - name: heldBy
+    from: Account
+    to: Party
+    annotations:
+      owl:inverseOf: holds
+      owl:characteristics: [Transitive]
+```
+
+Notes: no YAML comments needed in this example because every drop fit
+as an annotation value. Comments would appear if the source had
+restrictions, class expressions, or blank-node references.
+
+Running `ontology.md` validation on this file fails rule 11 (`Account`
+has no primary key). The user edits the `Account` entry, replacing
+`FILL_IN` with a real key (and optionally removing the comment):
+
+```yaml
+  - name: Account
+    description: Account
+    keys:
+      primary: [account_id]
+    properties:
+      - name: account_id
+        type: string
+```
+
+Notes on this output:
+- `Organization` and `Person` inherit Party's key via `extends`; the
+  importer does not need a placeholder for them.
+- Alphabetical ordering: `Account`, `Organization`, `Party`, `Person`.
+- This output uses `extends`, so the v0 compiler will reject it; that
+  is expected for a faithful import.


### PR DESCRIPTION
## Summary
- Add 5 ontology reference docs (`ontology.md`, `binding.md`, `compilation.md`, `cli.md`, `owl-import.md`) to `docs/ontology/` — the correct location alongside all other project documentation
- These docs were added to `src/ontology/docs/` on the upstream repo (GoogleCloudPlatform) but belong in the `docs/` tree
- Update `docs/README.md` with an "Ontology Reference" section indexing all 5 docs

## Test plan
- [ ] Verify all 5 docs present under `docs/ontology/`
- [ ] Verify `docs/README.md` links resolve correctly
- [ ] Follow up with upstream PR to relocate `src/ontology/docs/` → `docs/ontology/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)